### PR TITLE
Add Redux slices and selector tests

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "bracketSpacing": true,
+  "printWidth": 100,
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ export default tseslint.config({
       tsconfigRootDir: import.meta.dirname,
     },
   },
-})
+});
 ```
 
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js
 // eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+import reactX from 'eslint-plugin-react-x';
+import reactDom from 'eslint-plugin-react-dom';
 
 export default tseslint.config({
   plugins: {
@@ -50,5 +50,5 @@ export default tseslint.config({
     ...reactX.configs['recommended-typescript'].rules,
     ...reactDom.configs.recommended.rules,
   },
-})
+});
 ```

--- a/__tests__/insuranceSlice.test.ts
+++ b/__tests__/insuranceSlice.test.ts
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import reducer, {
+  setPrimaryInsurance,
+  updatePrimaryUsage,
+  setSecondaryInsurance,
+  updateSecondaryUsage,
+  clearSecondaryInsurance,
+  swapInsurances,
+} from '../src/store/insuranceSlice';
+
+const sampleIns = {
+  name: 'A',
+  deductible: 1000,
+  oopMax: 5000,
+  coInsurance: 0.2,
+  copay: 50,
+  usage: { deductibleUsed: 0, oopUsed: 0 },
+};
+
+test('setPrimaryInsurance replaces primary', () => {
+  const state = reducer(undefined, setPrimaryInsurance(sampleIns));
+  assert.equal(state.primary.name, 'A');
+});
+
+test('updatePrimaryUsage merges usage', () => {
+  const state = reducer({ primary: sampleIns }, updatePrimaryUsage({ deductibleUsed: 200 }));
+  assert.equal(state.primary.usage.deductibleUsed, 200);
+});
+
+test('setSecondaryInsurance sets secondary', () => {
+  const state = reducer({ primary: sampleIns }, setSecondaryInsurance(sampleIns));
+  assert.ok(state.secondary);
+});
+
+test('updateSecondaryUsage updates when secondary exists', () => {
+  const state = reducer(
+    { primary: sampleIns, secondary: sampleIns },
+    updateSecondaryUsage({ oopUsed: 100 })
+  );
+  assert.equal(state.secondary!.usage.oopUsed, 100);
+});
+
+test('clearSecondaryInsurance removes secondary', () => {
+  const state = reducer({ primary: sampleIns, secondary: sampleIns }, clearSecondaryInsurance());
+  assert.equal(state.secondary, undefined);
+});
+
+test('swapInsurances swaps when secondary exists', () => {
+  const state = reducer(
+    { primary: { ...sampleIns, name: 'P' }, secondary: { ...sampleIns, name: 'S' } },
+    swapInsurances()
+  );
+  assert.equal(state.primary.name, 'S');
+  assert.equal(state.secondary!.name, 'P');
+});
+
+test('swapInsurances does nothing without secondary', () => {
+  const state = reducer({ primary: sampleIns }, swapInsurances());
+  assert.equal(state.primary.name, 'A');
+  assert.equal(state.secondary, undefined);
+});

--- a/__tests__/proceduresSlice.test.ts
+++ b/__tests__/proceduresSlice.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import proceduresReducer, {
+  addProcedure,
+  removeProcedure,
+  toggleProcedure,
+  toggleAllProcedures,
+} from '../src/store/proceduresSlice';
+
+describe('proceduresSlice', () => {
+  let originalCrypto: typeof global.crypto;
+
+  beforeEach(() => {
+    // Save and mock crypto.randomUUID for deterministic tests
+    originalCrypto = global.crypto;
+    global.crypto = {
+      randomUUID: () => 'test-id',
+    } as unknown as Crypto;
+  });
+
+  afterEach(() => {
+    // Restore original crypto
+    global.crypto = originalCrypto;
+  });
+
+  it('should return the initial state', () => {
+    const result = proceduresReducer(undefined, { type: '' });
+    assert.deepStrictEqual(result, {
+      list: [],
+      selectedIds: {},
+    });
+  });
+
+  it('should add a procedure', () => {
+    const prevState = { list: [], selectedIds: {} as Record<string, boolean> };
+    const action = addProcedure({ id: 'ignored', name: 'Proc', cost: 100 });
+    const nextState = proceduresReducer(prevState, action);
+    assert.strictEqual(nextState.list.length, 1);
+    assert.deepStrictEqual(nextState.list[0], {
+      id: 'test-id',
+      name: 'Proc',
+      cost: 100,
+    });
+  });
+
+  it('should update a procedure', () => {
+    const prevState = {
+      list: [{ id: '1', name: 'Old', cost: 50 }],
+      selectedIds: {} as Record<string, boolean>,
+    };
+    const action = {
+      type: 'procedures/updateProcedure',
+      payload: { id: '1', name: 'New', cost: 200 },
+    };
+    const nextState = proceduresReducer(prevState, action);
+    assert.deepStrictEqual(nextState.list[0], {
+      id: '1',
+      name: 'New',
+      cost: 200,
+    });
+  });
+
+  it('should remove a procedure', () => {
+    const prevState = {
+      list: [
+        { id: '1', name: 'A', cost: 10 },
+        { id: '2', name: 'B', cost: 20 },
+      ],
+      selectedIds: {} as Record<string, boolean>,
+    };
+    const action = removeProcedure('1');
+    const nextState = proceduresReducer(prevState, action);
+    assert.strictEqual(nextState.list.length, 1);
+    assert.strictEqual(nextState.list[0].id, '2');
+  });
+
+  it('should toggle a procedure selection on', () => {
+    const prevState = {
+      list: [{ id: '1', name: 'A', cost: 10 }],
+      selectedIds: {} as Record<string, boolean>,
+    };
+    const action = toggleProcedure('1');
+    const nextState = proceduresReducer(prevState, action);
+    assert.strictEqual(nextState.selectedIds['1'], true);
+  });
+
+  it('should toggle a procedure selection off', () => {
+    const prevState = {
+      list: [{ id: '1', name: 'A', cost: 10 }],
+      selectedIds: { '1': true } as Record<string, boolean>,
+    };
+    const action = toggleProcedure('1');
+    const nextState = proceduresReducer(prevState, action);
+    assert.strictEqual(nextState.selectedIds['1'], undefined);
+  });
+
+  it('should toggle all procedures (select all)', () => {
+    const prevState = {
+      list: [
+        { id: '1', name: 'A', cost: 10 },
+        { id: '2', name: 'B', cost: 20 },
+      ],
+      selectedIds: {} as Record<string, boolean>,
+    };
+    const action = toggleAllProcedures();
+    const nextState = proceduresReducer(prevState, action);
+    assert.strictEqual(nextState.selectedIds['1'], true);
+    assert.strictEqual(nextState.selectedIds['2'], true);
+  });
+
+  it('should toggle all procedures (deselect all)', () => {
+    const prevState = {
+      list: [
+        { id: '1', name: 'A', cost: 10 },
+        { id: '2', name: 'B', cost: 20 },
+      ],
+      selectedIds: { '1': true, '2': true } as Record<string, boolean>,
+    };
+    const action = toggleAllProcedures();
+    const nextState = proceduresReducer(prevState, action);
+    assert.strictEqual(Object.keys(nextState.selectedIds).length, 0);
+  });
+});

--- a/__tests__/selectors.test.ts
+++ b/__tests__/selectors.test.ts
@@ -1,0 +1,196 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  sumSelectedProceduresCost,
+  patientResponsibilityAfterPrimary,
+  patientResponsibilityAfterSecondary,
+} from '../src/store';
+
+import type { Procedure, RootState } from '../src/store';
+
+const makeState = ({
+  procedures = {
+    list: [] as Procedure[],
+    selectedIds: {} as Record<string, boolean>,
+  },
+  insurance = {
+    primary: {
+      name: 'Primary Insurance',
+      deductible: 0,
+      oopMax: 0,
+      copay: 0,
+      coInsurance: 0,
+      usage: {
+        deductibleUsed: 0,
+        oopUsed: 0,
+      },
+    },
+    secondary: undefined,
+  },
+} = {}): RootState => ({
+  procedures,
+  insurance,
+});
+
+test.describe('Selectors', () => {
+  test.describe('sumSelectedProceduresCost', () => {
+    test.it('returns 0 if no procedures are selected', () => {
+      const state = makeState({
+        procedures: {
+          list: [{ id: '1', cost: 100, name: 'test' }],
+          selectedIds: {} as Record<string, boolean>,
+        },
+      });
+      assert.equal(sumSelectedProceduresCost(state), 0);
+    });
+
+    test.it('sums the cost of selected procedures', () => {
+      const state = makeState({
+        procedures: {
+          list: [
+            { id: '1', cost: 100, name: 'Procedure 1' },
+            { id: '2', cost: 200, name: 'Procedure 2' },
+            { id: '3', cost: 300, name: 'Procedure 3' },
+          ],
+          selectedIds: { '1': true, '3': true },
+        },
+      });
+      assert.equal(sumSelectedProceduresCost(state), 400);
+    });
+
+    test.it('ignores procedures without cost', () => {
+      const state = makeState({
+        procedures: {
+          list: [
+            { id: '1', cost: 100, name: 'Procedure 1' },
+            // @ts-expect-error: Intentionally omitting 'cost' to test selector behavior
+            { id: '2', name: 'Procedure 2' },
+            { id: '3', cost: 300, name: 'Procedure 3' },
+          ],
+          selectedIds: { '1': true, '2': true, '3': true },
+        },
+      });
+      assert.equal(sumSelectedProceduresCost(state), 400);
+    });
+
+    const insurance = {
+      name: 'Primary Insurance',
+      deductible: 500,
+      oopMax: 2000,
+      copay: 20,
+      coInsurance: 0.2,
+      usage: {
+        deductibleUsed: 100,
+        oopUsed: 300,
+      },
+    };
+
+    test.it('returns 0 if no procedures selected', () => {
+      const state = makeState({
+        procedures: {
+          list: [{ id: '1', cost: 100, name: 'Procedure 1' }],
+          selectedIds: {} as Record<string, boolean>,
+        },
+        insurance: {
+          primary: insurance,
+          secondary: undefined,
+        },
+      });
+      assert.equal(patientResponsibilityAfterPrimary(state), 0);
+    });
+
+    test.it('returns total cost if no insurance', () => {
+      const state = makeState({
+        procedures: {
+          list: [
+            { id: '1', cost: 100, name: 'Procedure 1' },
+            { id: '2', cost: 200, name: 'Procedure 2' },
+          ],
+          selectedIds: { '1': true, '2': true },
+        },
+        // @ts-expect-error: Intentionally omitting insurance to test selector behavior
+        insurance: { primary: undefined },
+      });
+      assert.equal(patientResponsibilityAfterPrimary(state), 300);
+    });
+
+    test.it('calculates responsibility with insurance', () => {
+      const state = makeState({
+        procedures: {
+          list: [
+            { id: '1', cost: 100, name: 'Procedure 1' },
+            { id: '2', cost: 200, name: 'Procedure 2' },
+          ],
+          selectedIds: { '1': true, '2': true },
+        },
+        insurance: { primary: insurance, secondary: undefined },
+      });
+      // total cost: 300, deductible left: 400
+      // patient pays 300 (all goes to deductible)
+      assert.equal(patientResponsibilityAfterPrimary(state), 300);
+    });
+    const primary = {
+      name: 'Primary Insurance',
+      deductible: 500,
+      oopMax: 2000,
+      copay: 20,
+      coInsurance: 0.2,
+      usage: {
+        deductibleUsed: 500,
+        oopUsed: 500,
+      },
+    };
+    const secondary = {
+      name: 'Secondary Insurance',
+      deductible: 100,
+      oopMax: 1000,
+      copay: 10,
+      coInsurance: 0.1,
+      usage: {
+        deductibleUsed: 0,
+        oopUsed: 0,
+      },
+    };
+
+    test.it('returns 0 if no procedures selected', () => {
+      const state = makeState({
+        procedures: {
+          list: [{ id: '1', cost: 100, name: 'Procedure 1' }],
+          selectedIds: {} as Record<string, boolean>,
+        },
+        // @ts-expect-error: Intentionally omitting secondary insurance to test selector behavior
+        insurance: { primary, secondary },
+      });
+      assert.equal(patientResponsibilityAfterSecondary(state), 0);
+    });
+
+    test.it('applies secondary insurance to remaining responsibility', () => {
+      const state = makeState({
+        procedures: {
+          list: [{ id: '1', cost: 500, name: 'Procedure 1' }],
+          selectedIds: { '1': true },
+        },
+        // @ts-expect-error: Intentionally omitting secondary insurance to test selector behavior
+        insurance: { primary, secondary },
+      });
+      // primary: deductible met, so copay + coinsurance: 20 + 0.2*500 = 120
+      // secondary: deductible left 100, so pays 100, remaining 20, copay 10, coinsurance 0.1*20=2, total 100+10+2=112
+      assert.equal(patientResponsibilityAfterSecondary(state), 112);
+    });
+
+    test.it('returns primary responsibility if no secondary insurance', () => {
+      const state = makeState({
+        procedures: {
+          list: [{ id: '1', cost: 500, name: 'Procedure 1' }],
+          selectedIds: { '1': true },
+        },
+        insurance: { primary, secondary: undefined },
+      });
+      // primary: 20 + 0.2*500 = 120
+      assert.equal(
+        patientResponsibilityAfterSecondary(state),
+        patientResponsibilityAfterPrimary(state),
+      );
+    });
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,8 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   { ignores: ['dist'] },
@@ -19,10 +19,7 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
   },
-)
+);

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,13 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react-swc": "^3.9.0",
+        "c8": "^10.1.2",
         "cz-conventional-changelog": "^3.3.0",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
+        "tsx": "^4.19.4",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5"
@@ -67,6 +69,15 @@
       "optional": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -827,6 +838,102 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -837,6 +944,15 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -923,6 +1039,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -1732,6 +1858,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2226,6 +2358,39 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/c8": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
+      "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.1",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^7.0.1",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "monocart-coverage-reports": "^2"
+      },
+      "peerDependenciesMeta": {
+        "monocart-coverage-reports": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cachedir": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
@@ -2310,6 +2475,20 @@
         "node": ">= 10"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
@@ -2380,6 +2559,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-3.0.0.tgz",
       "integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg==",
+      "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
     "node_modules/cosmiconfig": {
@@ -2619,6 +2804,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2696,6 +2887,15 @@
         "@esbuild/win32-arm64": "0.25.5",
         "@esbuild/win32-ia32": "0.25.5",
         "@esbuild/win32-x64": "0.25.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -3112,6 +3312,34 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -3145,6 +3373,27 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "devOptional": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -3292,6 +3541,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -3526,6 +3781,57 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.4.2",
@@ -3936,6 +4242,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -3943,6 +4255,21 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge": {
@@ -4186,6 +4513,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4254,6 +4587,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/picocolors": {
@@ -4414,6 +4763,15 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4450,6 +4808,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "devOptional": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/restore-cursor": {
@@ -4669,7 +5036,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -4746,6 +5141,64 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/through": {
@@ -4839,6 +5292,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "devOptional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.19.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
+      "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
+      "devOptional": true,
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4940,6 +5412,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
     },
     "node_modules/vite": {
       "version": "6.3.5",
@@ -5093,11 +5579,38 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yallist": {
       "version": "5.0.0",
@@ -5106,6 +5619,33 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "c8 node --import tsx --test __tests__/*.test.ts",
+    "test:watch": "c8 node --import tsx --test --watch __tests__/*.test.ts"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.8.2",
@@ -30,7 +32,9 @@
     "globals": "^16.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "c8": "^10.1.2",
+    "tsx": "^4.19.4"
   },
   "config": {
     "commitizen": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useState } from 'react';
+import reactLogo from './assets/react.svg';
+import viteLogo from '/vite.svg';
+import './App.css';
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [count, setCount] = useState(0);
 
   return (
     <>
@@ -18,18 +18,14 @@ function App() {
       </div>
       <h1>Vite + React</h1>
       <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
+        <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 @plugin "daisyui";
 
 :root {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,14 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.tsx';
+import { Provider } from 'react-redux';
+import { store } from './store';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </StrictMode>,
-)
+);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,18 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+import proceduresReducer from './proceduresSlice';
+import insuranceReducer from './insuranceSlice';
+
+export const store = configureStore({
+  reducer: {
+    procedures: proceduresReducer,
+    insurance: insuranceReducer,
+  },
+});
+
+export * from './selectors';
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+export type { Procedure, ProcedureCreate, ProcedureUpdate } from './proceduresSlice';
+export type { Insurance, InsuranceUsage } from './insuranceSlice';

--- a/src/store/insuranceSlice.ts
+++ b/src/store/insuranceSlice.ts
@@ -1,0 +1,79 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+export interface InsuranceUsage {
+  deductibleUsed: number;
+  oopUsed: number;
+}
+
+export interface Insurance {
+  name: string;
+  deductible: number;
+  oopMax: number;
+  coInsurance: number;
+  copay: number;
+  usage: InsuranceUsage;
+}
+
+interface InsuranceState {
+  primary: Insurance;
+  secondary?: Insurance;
+}
+
+const emptyInsurance: Insurance = {
+  name: '',
+  deductible: 0,
+  oopMax: 0,
+  coInsurance: 0,
+  copay: 0,
+  usage: {
+    deductibleUsed: 0,
+    oopUsed: 0,
+  },
+};
+
+const initialState: InsuranceState = {
+  primary: emptyInsurance,
+};
+
+const insuranceSlice = createSlice({
+  name: 'insurance',
+  initialState,
+  reducers: {
+    setPrimaryInsurance: (state, action: PayloadAction<Insurance>) => {
+      state.primary = action.payload;
+    },
+    updatePrimaryUsage: (state, action: PayloadAction<Partial<InsuranceUsage>>) => {
+      state.primary.usage = { ...state.primary.usage, ...action.payload };
+    },
+    setSecondaryInsurance: (state, action: PayloadAction<Insurance>) => {
+      state.secondary = action.payload;
+    },
+    updateSecondaryUsage: (state, action: PayloadAction<Partial<InsuranceUsage>>) => {
+      if (state.secondary) {
+        state.secondary.usage = { ...state.secondary.usage, ...action.payload };
+      }
+    },
+    clearSecondaryInsurance: (state) => {
+      state.secondary = undefined;
+    },
+    swapInsurances: (state) => {
+      if (state.secondary) {
+        const temp = state.primary;
+        state.primary = state.secondary;
+        state.secondary = temp;
+      }
+    },
+  },
+});
+
+export const {
+  setPrimaryInsurance,
+  updatePrimaryUsage,
+  setSecondaryInsurance,
+  updateSecondaryUsage,
+  clearSecondaryInsurance,
+  swapInsurances,
+} = insuranceSlice.actions;
+
+export default insuranceSlice.reducer;

--- a/src/store/proceduresSlice.ts
+++ b/src/store/proceduresSlice.ts
@@ -1,0 +1,67 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+export interface Procedure {
+  id: string;
+  name: string;
+  cost: number;
+}
+
+export type ProcedureCreate = Omit<Procedure, 'id'>;
+export type ProcedureUpdate = Partial<Procedure> & { id: string };
+
+interface ProceduresState {
+  list: Procedure[];
+  selectedIds: { [id: string]: boolean };
+}
+
+const initialState: ProceduresState = {
+  list: [],
+  selectedIds: {},
+};
+
+const proceduresSlice = createSlice({
+  name: 'procedures',
+  initialState,
+  reducers: {
+    addProcedure: (state, action: PayloadAction<Procedure>) => {
+      state.list.push({ ...action.payload, id: crypto.randomUUID() });
+    },
+    updateProcedure: (
+      state,
+      action: PayloadAction<{ id: string; name?: string; cost?: number }>,
+    ) => {
+      const { id, name, cost } = action.payload;
+      const procedure = state.list.find((p) => p.id === id);
+      if (procedure) {
+        if (name !== undefined) procedure.name = name;
+        if (cost !== undefined) procedure.cost = cost;
+      }
+    },
+    removeProcedure: (state, action: PayloadAction<string>) => {
+      state.list = state.list.filter((p) => p.id !== action.payload);
+    },
+    toggleProcedure: (state, action: PayloadAction<string>) => {
+      const id = action.payload;
+      if (state.selectedIds[id]) {
+        delete state.selectedIds[id];
+      } else {
+        state.selectedIds[id] = true;
+      }
+    },
+    toggleAllProcedures: (state) => {
+      if (Object.keys(state.selectedIds).length === state.list.length) {
+        // If all are selected, clear selection
+        state.selectedIds = {};
+      } else {
+        // Otherwise, select all
+        state.selectedIds = Object.fromEntries(state.list.map((p) => [p.id, true]));
+      }
+    },
+  },
+});
+
+export const { addProcedure, removeProcedure, toggleProcedure, toggleAllProcedures } =
+  proceduresSlice.actions;
+
+export default proceduresSlice.reducer;

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -1,0 +1,56 @@
+import { createSelector } from '@reduxjs/toolkit';
+import type { RootState } from './index';
+import type { Insurance } from './insuranceSlice';
+
+export const sumSelectedProceduresCost = createSelector(
+  (state: RootState) => state.procedures,
+  ({ list, selectedIds }) => {
+    return Object.keys(selectedIds)
+      .map((id) => list.find((p) => p.id === id))
+      .filter((p) => !!p?.cost)
+      .reduce((sum, p) => sum + p!.cost, 0);
+  },
+);
+
+const _calculatePatientResponsibility = (
+  insurance: Insurance | undefined,
+  totalCost: number,
+): number => {
+  if (totalCost <= 0) {
+    return 0;
+  }
+  if (!insurance) {
+    return totalCost;
+  }
+
+  const remainingDeductible = Math.max(insurance.deductible - insurance.usage.deductibleUsed, 0);
+  const remainingOop = Math.max(insurance.oopMax - insurance.usage.oopUsed, 0);
+
+  let patientCost = 0;
+  let remainingCost = totalCost;
+
+  const deductibleAmount = Math.min(remainingCost, remainingDeductible);
+  patientCost += deductibleAmount;
+  remainingCost -= deductibleAmount;
+
+  if (remainingCost > 0) {
+    patientCost += insurance.copay;
+  }
+
+  const coinsuranceAmount = remainingCost * insurance.coInsurance;
+  patientCost += coinsuranceAmount;
+
+  return Math.min(patientCost, remainingOop);
+};
+
+export const patientResponsibilityAfterPrimary = createSelector(
+  (state: RootState) => state.insurance.primary,
+  sumSelectedProceduresCost,
+  _calculatePatientResponsibility,
+);
+
+export const patientResponsibilityAfterSecondary = createSelector(
+  (state: RootState) => state.insurance.secondary,
+  patientResponsibilityAfterPrimary,
+  _calculatePatientResponsibility,
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": ".test-dist",
+    "allowImportingTsExtensions": false,
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
-import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+import tailwindcss from '@tailwindcss/vite';
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- implement procedures and insurance slices
- add redux store and cost selectors
- configure TypeScript for tests
- add unit tests using node:test
- run tests with c8 and tsx

## Testing
- `npm run test` *(fails: c8: not found)*

------
https://chatgpt.com/codex/tasks/task_b_684276b44d308325addef2cba28f7081