### PR TITLE
feat(procedures): show invalid input feedback

### DIFF
--- a/src/components/ProcedureItem.tsx
+++ b/src/components/ProcedureItem.tsx
@@ -12,6 +12,16 @@ export default function ProcedureItem({ procedure }: ProcedureItemProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [name, setName] = useState(procedure.name);
   const [cost, setCost] = useState(procedure.cost.toString());
+  const parsedCost = parseFloat(cost);
+  const isInvalid = !name.trim() || isNaN(parsedCost) || parsedCost < 0;
+  let errorMessage = '';
+  if (!name.trim()) {
+    errorMessage = 'Name is required';
+  } else if (isNaN(parsedCost)) {
+    errorMessage = 'Cost is required';
+  } else if (parsedCost < 0) {
+    errorMessage = 'Cost cannot be negative';
+  }
 
   const startEdit = useCallback(() => {
     setIsEditing(true);
@@ -24,9 +34,9 @@ export default function ProcedureItem({ procedure }: ProcedureItemProps) {
   }, [procedure.cost, procedure.name]);
 
   const saveEdit = useCallback(() => {
-    const parsedCost = parseFloat(cost);
-    if (!name || isNaN(parsedCost)) return;
-    dispatch(updateProcedure({ id: procedure.id, name, cost: parsedCost }));
+    const parsed = parseFloat(cost);
+    if (!name.trim() || isNaN(parsed) || parsed < 0) return;
+    dispatch(updateProcedure({ id: procedure.id, name, cost: parsed }));
     setIsEditing(false);
   }, [dispatch, cost, name, procedure.id]);
 
@@ -61,15 +71,23 @@ export default function ProcedureItem({ procedure }: ProcedureItemProps) {
           <input
             type="number"
             className="input input-bordered w-24"
+            min="0"
             value={cost}
             onChange={handleCostChange}
           />
-          <button className="btn btn-primary btn-sm" onClick={saveEdit}>
+          <button
+            className="btn btn-primary btn-sm"
+            onClick={saveEdit}
+            disabled={isInvalid}
+          >
             Save
           </button>
           <button className="btn btn-ghost btn-sm" onClick={cancelEdit}>
             Cancel
           </button>
+          {errorMessage && (
+            <p className="text-error text-sm">{errorMessage}</p>
+          )}
         </>
       ) : (
         <>

--- a/src/components/ProceduresCard.tsx
+++ b/src/components/ProceduresCard.tsx
@@ -10,6 +10,16 @@ export default function ProceduresCard() {
 
   const [name, setName] = useState('');
   const [cost, setCost] = useState('');
+  const parsedCost = parseFloat(cost);
+  const isInvalid = !name.trim() || isNaN(parsedCost) || parsedCost < 0;
+  let errorMessage = '';
+  if (!name.trim()) {
+    errorMessage = 'Name is required';
+  } else if (isNaN(parsedCost)) {
+    errorMessage = 'Cost is required';
+  } else if (parsedCost < 0) {
+    errorMessage = 'Cost cannot be negative';
+  }
 
   const handleNameChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,16 +41,16 @@ export default function ProceduresCard() {
   }, []);
 
   const handleAdd = useCallback(() => {
-    const parsedCost = parseFloat(cost);
-    if (!name || isNaN(parsedCost)) return;
-    dispatch(addProcedure({ id: '', name, cost: parsedCost } as Procedure));
+    const parsed = parseFloat(cost);
+    if (!name.trim() || isNaN(parsed) || parsed < 0) return;
+    dispatch(addProcedure({ id: '', name, cost: parsed } as Procedure));
     resetAddForm();
   }, [cost, name, dispatch, resetAddForm]);
 
   return (
     <div className="card bg-base-200 shadow-xl p-4">
       <h2 className="card-title mb-4">Procedures</h2>
-      <div className="flex gap-2 mb-4">
+      <div className="flex gap-2 mb-2 items-start">
         <input
           type="text"
           placeholder="Name"
@@ -52,13 +62,21 @@ export default function ProceduresCard() {
           type="number"
           placeholder="Cost"
           className="input input-bordered w-24"
+          min="0"
           value={cost}
           onChange={handleCostChange}
         />
-        <button className="btn btn-primary" onClick={handleAdd}>
+        <button
+          className="btn btn-primary"
+          onClick={handleAdd}
+          disabled={isInvalid}
+        >
           Add
         </button>
       </div>
+      {errorMessage && (
+        <p className="text-error text-sm mb-4">{errorMessage}</p>
+      )}
       <ul className="space-y-2">
         {procedures.map((p) => (
           <ProcedureItem key={p.id} procedure={p} />


### PR DESCRIPTION
## Summary
- show validation feedback in the procedure form
- disable add/save buttons when inputs are invalid

## Testing
- `npm test` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_b_684498152e008325b09a4744ec48d97a