### PR TITLE
Add manual deploy workflow

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,0 +1,34 @@
+name: manual-deploy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION

This pull request introduces a new GitHub Actions workflow for manual deployment to GitHub Pages. The workflow allows developers to trigger deployments manually and ensures concurrency control to avoid overlapping deployments.

### Deployment workflow changes:

* [`.github/workflows/manual-deploy.yml`](diffhunk://#diff-20ebf81d2d7ab4f92c7e9e549551d91cde8927c0718a525e99aaef5ba44939d8R1-R34): Added a new workflow named `manual-deploy` triggered by `workflow_dispatch`. It includes permissions for reading contents, writing pages, and using an ID token, and defines a `deploy` job to build and deploy the project to GitHub Pages. The job uses `actions/checkout`, `actions/setup-node`, `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages` actions.