### PR TITLE
Add insurance plan card

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,10 @@ function App() {
   const { primary, secondary } = useSelector((state: RootState) => state.insurance);
   const [showSecondary, setShowSecondary] = useState(Boolean(secondary));
 
+  // Synchronize showSecondary with the Redux state
+  useEffect(() => {
+    setShowSecondary(Boolean(secondary));
+  }, [secondary]);
   const handlePrimaryChange = useCallback(
     (ins: Insurance) => {
       dispatch(setPrimaryInsurance(ins));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,81 @@
+import { useState, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import './App.css';
 import ProceduresCard from './components/ProceduresCard';
+import InsuranceCard from './components/InsuranceCard';
+import type { AppDispatch, RootState, Insurance } from './store';
+import {
+  setPrimaryInsurance,
+  setSecondaryInsurance,
+  clearSecondaryInsurance,
+} from './store/insuranceSlice';
+
+const emptyInsurance: Insurance = {
+  name: '',
+  deductible: 0,
+  oopMax: 0,
+  coInsurance: 0,
+  copay: 0,
+  usage: {
+    deductibleUsed: 0,
+    oopUsed: 0,
+  },
+};
 
 function App() {
+  const dispatch = useDispatch<AppDispatch>();
+  const { primary, secondary } = useSelector((state: RootState) => state.insurance);
+  const [showSecondary, setShowSecondary] = useState(Boolean(secondary));
+
+  const handlePrimaryChange = useCallback(
+    (ins: Insurance) => {
+      dispatch(setPrimaryInsurance(ins));
+    },
+    [dispatch],
+  );
+
+  const handleSecondaryChange = useCallback(
+    (ins: Insurance) => {
+      dispatch(setSecondaryInsurance(ins));
+    },
+    [dispatch],
+  );
+
+  const addSecondary = useCallback(() => {
+    setShowSecondary(true);
+    if (!secondary) {
+      dispatch(setSecondaryInsurance(emptyInsurance));
+    }
+  }, [dispatch, secondary]);
+
+  const removeSecondary = useCallback(() => {
+    setShowSecondary(false);
+    dispatch(clearSecondaryInsurance());
+  }, [dispatch]);
+
   return (
-    <div className="p-4">
+    <div className="p-4 space-y-4">
+      <InsuranceCard
+        label="Primary Insurance"
+        insurance={primary}
+        onChange={handlePrimaryChange}
+      />
+      {showSecondary ? (
+        <div className="space-y-2">
+          <InsuranceCard
+            label="Secondary Insurance"
+            insurance={secondary || emptyInsurance}
+            onChange={handleSecondaryChange}
+          />
+          <button className="btn" onClick={removeSecondary}>
+            Remove Secondary
+          </button>
+        </div>
+      ) : (
+        <button className="btn" onClick={addSecondary}>
+          Add Secondary Insurance
+        </button>
+      )}
       <ProceduresCard />
     </div>
   );

--- a/src/components/InsuranceCard.tsx
+++ b/src/components/InsuranceCard.tsx
@@ -1,0 +1,118 @@
+import { useCallback } from 'react';
+import type { Insurance } from '../store';
+
+interface InsuranceCardProps {
+  label: string;
+  insurance: Insurance;
+  onChange: (insurance: Insurance) => void;
+}
+
+export default function InsuranceCard({ label, insurance, onChange }: InsuranceCardProps) {
+  const handleChange = useCallback(
+    (field: keyof Insurance) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = field === 'name' ? e.target.value : Number(e.target.value);
+      onChange({ ...insurance, [field]: value });
+    },
+    [insurance, onChange],
+  );
+
+  const handleUsageChange = useCallback(
+    (field: keyof Insurance['usage']) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = Number(e.target.value);
+      onChange({
+        ...insurance,
+        usage: { ...insurance.usage, [field]: value },
+      });
+    },
+    [insurance, onChange],
+  );
+
+  return (
+    <div className="card bg-base-200 shadow-xl p-4">
+      <h2 className="card-title mb-4">
+        <i aria-hidden="true" className="fa-solid fa-shield-halved mr-2" />
+        {label}
+      </h2>
+      <div className="flex flex-col gap-2">
+        <label className="input input-bordered flex items-center gap-2">
+          <i aria-hidden="true" className="fa-solid fa-id-card opacity-50" />
+          <input
+            type="text"
+            className="grow"
+            placeholder="Name"
+            value={insurance.name}
+            onChange={handleChange('name')}
+          />
+        </label>
+        <label className="input input-bordered flex items-center gap-2">
+          <span className="opacity-50">$</span>
+          <input
+            type="number"
+            className="grow"
+            placeholder="Deductible"
+            min="0"
+            value={insurance.deductible}
+            onChange={handleChange('deductible')}
+          />
+        </label>
+        <label className="input input-bordered flex items-center gap-2">
+          <span className="opacity-50">$</span>
+          <input
+            type="number"
+            className="grow"
+            placeholder="Out-of-pocket Max"
+            min="0"
+            value={insurance.oopMax}
+            onChange={handleChange('oopMax')}
+          />
+        </label>
+        <label className="input input-bordered flex items-center gap-2">
+          <span className="opacity-50">$</span>
+          <input
+            type="number"
+            className="grow"
+            placeholder="Copay"
+            min="0"
+            value={insurance.copay}
+            onChange={handleChange('copay')}
+          />
+        </label>
+        <label className="input input-bordered flex items-center gap-2">
+          <span className="opacity-50">%</span>
+          <input
+            type="number"
+            className="grow"
+            placeholder="Coinsurance"
+            step="0.01"
+            min="0"
+            max="1"
+            value={insurance.coInsurance}
+            onChange={handleChange('coInsurance')}
+          />
+        </label>
+        <label className="input input-bordered flex items-center gap-2">
+          <span className="opacity-50">$</span>
+          <input
+            type="number"
+            className="grow"
+            placeholder="Deductible Used"
+            min="0"
+            value={insurance.usage.deductibleUsed}
+            onChange={handleUsageChange('deductibleUsed')}
+          />
+        </label>
+        <label className="input input-bordered flex items-center gap-2">
+          <span className="opacity-50">$</span>
+          <input
+            type="number"
+            className="grow"
+            placeholder="OOP Used"
+            min="0"
+            value={insurance.usage.oopUsed}
+            onChange={handleUsageChange('oopUsed')}
+          />
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/components/InsuranceCard.tsx
+++ b/src/components/InsuranceCard.tsx
@@ -8,10 +8,25 @@ interface InsuranceCardProps {
 }
 
 export default function InsuranceCard({ label, insurance, onChange }: InsuranceCardProps) {
+  const updateInsuranceField = (
+    insurance: Insurance,
+    field: keyof Insurance | keyof Insurance['usage'],
+    value: string | number,
+    nestedField?: 'usage',
+  ): Insurance => {
+    if (nestedField) {
+      return {
+        ...insurance,
+        [nestedField]: { ...insurance[nestedField], [field]: value },
+      };
+    }
+    return { ...insurance, [field]: value };
+  };
+
   const handleChange = useCallback(
     (field: keyof Insurance) => (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = field === 'name' ? e.target.value : Number(e.target.value);
-      onChange({ ...insurance, [field]: value });
+      onChange(updateInsuranceField(insurance, field, value));
     },
     [insurance, onChange],
   );


### PR DESCRIPTION
This pull request introduces functionality to manage primary and secondary insurance policies in the application. It adds a new `InsuranceCard` component for displaying and editing insurance details, along with updates to the `App.tsx` file to integrate this functionality. The changes focus on improving the user interface and state management for insurance data.

### New Insurance Management Features:

* **Integration of Insurance Management in `App.tsx`:**
  - Added state management for primary and secondary insurance using Redux and React hooks (`useState`, `useDispatch`, `useSelector`). This includes actions for setting and clearing insurance data.
  - Implemented UI logic to toggle between adding and removing secondary insurance, with corresponding buttons and handlers.

* **Creation of `InsuranceCard` Component:**
  - Introduced a reusable `InsuranceCard` component for displaying and editing insurance details, including fields for name, deductible, out-of-pocket maximum, copay, coinsurance, and usage metrics.
  - Added input handling logic using `useCallback` to update insurance fields and nested usage fields dynamically.