### PR TITLE
Add corner actions for secondary insurance management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ function App() {
         onChange={handlePrimaryChange}
         cornerButton={
           !secondary && (
-            <button className="btn btn-circle btn-sm btn-primary" onClick={addSecondary}>
+            <button className="btn btn-circle btn-sm btn-primary" onClick={addSecondary} aria-label="Add Secondary Insurance">
               <i className="fa-solid fa-plus" aria-hidden="true" />
             </button>
           )
@@ -69,7 +69,7 @@ function App() {
           insurance={secondary}
           onChange={handleSecondaryChange}
           cornerButton={
-            <button className="btn btn-circle btn-sm btn-error" onClick={removeSecondary}>
+            <button className="btn btn-circle btn-sm btn-error" onClick={removeSecondary} aria-label="Remove Secondary Insurance">
               <i className="fa-solid fa-trash" aria-hidden="true" />
             </button>
           }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import './App.css';
 import ProceduresCard from './components/ProceduresCard';
@@ -25,12 +25,6 @@ const emptyInsurance: Insurance = {
 function App() {
   const dispatch = useDispatch<AppDispatch>();
   const { primary, secondary } = useSelector((state: RootState) => state.insurance);
-  const [showSecondary, setShowSecondary] = useState(Boolean(secondary));
-
-  // Synchronize showSecondary with the Redux state
-  useEffect(() => {
-    setShowSecondary(Boolean(secondary));
-  }, [secondary]);
   const handlePrimaryChange = useCallback(
     (ins: Insurance) => {
       dispatch(setPrimaryInsurance(ins));
@@ -46,35 +40,40 @@ function App() {
   );
 
   const addSecondary = useCallback(() => {
-    setShowSecondary(true);
     if (!secondary) {
       dispatch(setSecondaryInsurance(emptyInsurance));
     }
   }, [dispatch, secondary]);
 
   const removeSecondary = useCallback(() => {
-    setShowSecondary(false);
     dispatch(clearSecondaryInsurance());
   }, [dispatch]);
 
   return (
     <div className="p-4 space-y-4">
-      <InsuranceCard label="Primary Insurance" insurance={primary} onChange={handlePrimaryChange} />
-      {showSecondary ? (
-        <div className="space-y-2">
-          <InsuranceCard
-            label="Secondary Insurance"
-            insurance={secondary || emptyInsurance}
-            onChange={handleSecondaryChange}
-          />
-          <button className="btn" onClick={removeSecondary}>
-            Remove Secondary
-          </button>
-        </div>
-      ) : (
-        <button className="btn" onClick={addSecondary}>
-          Add Secondary Insurance
-        </button>
+      <InsuranceCard
+        label="Primary Insurance"
+        insurance={primary}
+        onChange={handlePrimaryChange}
+        cornerButton={
+          !secondary && (
+            <button className="btn btn-circle btn-sm btn-primary" onClick={addSecondary}>
+              <i className="fa-solid fa-plus" aria-hidden="true" />
+            </button>
+          )
+        }
+      />
+      {secondary && (
+        <InsuranceCard
+          label="Secondary Insurance"
+          insurance={secondary}
+          onChange={handleSecondaryChange}
+          cornerButton={
+            <button className="btn btn-circle btn-sm btn-error" onClick={removeSecondary}>
+              <i className="fa-solid fa-trash" aria-hidden="true" />
+            </button>
+          }
+        />
       )}
       <ProceduresCard />
     </div>

--- a/src/components/InsuranceCard.tsx
+++ b/src/components/InsuranceCard.tsx
@@ -1,13 +1,14 @@
-import { useCallback } from 'react';
+import { useCallback, type ReactNode } from 'react';
 import type { Insurance } from '../store';
 
 interface InsuranceCardProps {
   label: string;
   insurance: Insurance;
   onChange: (insurance: Insurance) => void;
+  cornerButton?: ReactNode;
 }
 
-export default function InsuranceCard({ label, insurance, onChange }: InsuranceCardProps) {
+export default function InsuranceCard({ label, insurance, onChange, cornerButton }: InsuranceCardProps) {
   const updateInsuranceField = (
     insurance: Insurance,
     field: keyof Insurance | keyof Insurance['usage'],
@@ -43,7 +44,8 @@ export default function InsuranceCard({ label, insurance, onChange }: InsuranceC
   );
 
   return (
-    <div className="card bg-base-200 shadow-xl p-4">
+    <div className="card bg-base-200 shadow-xl p-4 relative">
+      {cornerButton && <div className="absolute right-2 top-2">{cornerButton}</div>}
       <h2 className="card-title mb-4">
         <i aria-hidden="true" className="fa-solid fa-shield-halved mr-2" />
         {label}


### PR DESCRIPTION
This pull request refactors the insurance card functionality in the `App` component to improve its usability and simplify state management. The most notable changes include removing the `showSecondary` local state and synchronizing directly with the Redux state, adding a `cornerButton` prop to the `InsuranceCard` component for better UI integration, and updating the `App` component to leverage these improvements.

### Refactoring State Management
* Removed the `showSecondary` local state in `src/App.tsx` and its synchronization with the Redux state. The component now directly relies on the `secondary` state from Redux, simplifying state handling. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L1-R1) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L28-L33) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L49-R76)

### UI Enhancements
* Added a `cornerButton` prop to the `InsuranceCard` component in `src/components/InsuranceCard.tsx`, allowing for customizable buttons in the top-right corner of the card.
* Updated the `InsuranceCard` layout to include the `cornerButton` in the UI, positioned absolutely within the card.
* Refactored the `App` component to use the `cornerButton` prop for adding and removing secondary insurance, replacing the previous inline buttons.