### PR TITLE
Center align insurance card inputs

### DIFF
--- a/src/components/InsuranceCard.tsx
+++ b/src/components/InsuranceCard.tsx
@@ -53,7 +53,7 @@ export default function InsuranceCard({ label, insurance, onChange }: InsuranceC
           <i aria-hidden="true" className="fa-solid fa-id-card opacity-50" />
           <input
             type="text"
-            className="grow"
+            className="grow text-center"
             placeholder="Name"
             value={insurance.name}
             onChange={handleChange('name')}
@@ -63,7 +63,7 @@ export default function InsuranceCard({ label, insurance, onChange }: InsuranceC
           <span className="opacity-50">$</span>
           <input
             type="number"
-            className="grow"
+            className="grow text-center"
             placeholder="Deductible"
             min="0"
             value={insurance.deductible}
@@ -74,7 +74,7 @@ export default function InsuranceCard({ label, insurance, onChange }: InsuranceC
           <span className="opacity-50">$</span>
           <input
             type="number"
-            className="grow"
+            className="grow text-center"
             placeholder="Out-of-pocket Max"
             min="0"
             value={insurance.oopMax}
@@ -85,7 +85,7 @@ export default function InsuranceCard({ label, insurance, onChange }: InsuranceC
           <span className="opacity-50">$</span>
           <input
             type="number"
-            className="grow"
+            className="grow text-center"
             placeholder="Copay"
             min="0"
             value={insurance.copay}
@@ -96,7 +96,7 @@ export default function InsuranceCard({ label, insurance, onChange }: InsuranceC
           <span className="opacity-50">%</span>
           <input
             type="number"
-            className="grow"
+            className="grow text-center"
             placeholder="Coinsurance"
             step="0.01"
             min="0"
@@ -109,7 +109,7 @@ export default function InsuranceCard({ label, insurance, onChange }: InsuranceC
           <span className="opacity-50">$</span>
           <input
             type="number"
-            className="grow"
+            className="grow text-center"
             placeholder="Deductible Used"
             min="0"
             value={insurance.usage.deductibleUsed}
@@ -120,7 +120,7 @@ export default function InsuranceCard({ label, insurance, onChange }: InsuranceC
           <span className="opacity-50">$</span>
           <input
             type="number"
-            className="grow"
+            className="grow text-center"
             placeholder="OOP Used"
             min="0"
             value={insurance.usage.oopUsed}


### PR DESCRIPTION
This pull request modifies the `InsuranceCard` component in `src/components/InsuranceCard.tsx` to improve the visual alignment of input fields by adding the `text-center` class to all relevant input elements.

Styling updates for input fields:

* Updated the `Name` field to include the `text-center` class for better visual alignment.
* Updated the `Deductible`, `Out-of-pocket Max`, `Copay`, `Coinsurance`, `Deductible Used`, and `OOP Used` fields to include the `text-center` class for consistent styling across numeric input fields. [[1]](diffhunk://#diff-595a940befeb13c7d61202d64b9df6bbc6363dfe8e5971ae69c492ae1b80f93cL66-R66) [[2]](diffhunk://#diff-595a940befeb13c7d61202d64b9df6bbc6363dfe8e5971ae69c492ae1b80f93cL77-R77) [[3]](diffhunk://#diff-595a940befeb13c7d61202d64b9df6bbc6363dfe8e5971ae69c492ae1b80f93cL88-R88) [[4]](diffhunk://#diff-595a940befeb13c7d61202d64b9df6bbc6363dfe8e5971ae69c492ae1b80f93cL99-R99) [[5]](diffhunk://#diff-595a940befeb13c7d61202d64b9df6bbc6363dfe8e5971ae69c492ae1b80f93cL112-R112) [[6]](diffhunk://#diff-595a940befeb13c7d61202d64b9df6bbc6363dfe8e5971ae69c492ae1b80f93cL123-R123)