### PR TITLE
Remove unused insurance name field

### DIFF
--- a/__tests__/insuranceSlice.test.ts
+++ b/__tests__/insuranceSlice.test.ts
@@ -10,7 +10,6 @@ import reducer, {
 } from '../src/store/insuranceSlice';
 
 const sampleIns = {
-  name: 'A',
   deductible: 1000,
   oopMax: 5000,
   coInsurance: 0.2,
@@ -20,7 +19,7 @@ const sampleIns = {
 
 test('setPrimaryInsurance replaces primary', () => {
   const state = reducer(undefined, setPrimaryInsurance(sampleIns));
-  assert.equal(state.primary.name, 'A');
+  assert.equal(state.primary.oopMax, 5000);
 });
 
 test('updatePrimaryOOPUsage merges usage', () => {
@@ -45,15 +44,15 @@ test('clearSecondaryInsurance removes secondary', () => {
 
 test('swapInsurances swaps when secondary exists', () => {
   const state = reducer(
-    { primary: { ...sampleIns, name: 'P' }, secondary: { ...sampleIns, name: 'S' } },
+    { primary: sampleIns, secondary: { ...sampleIns, copay: 10 } },
     swapInsurances()
   );
-  assert.equal(state.primary.name, 'S');
-  assert.equal(state.secondary!.name, 'P');
+  assert.strictEqual(state.primary.copay, 10);
+  assert.strictEqual(state.secondary!.copay, 50);
 });
 
 test('swapInsurances does nothing without secondary', () => {
   const state = reducer({ primary: sampleIns }, swapInsurances());
-  assert.equal(state.primary.name, 'A');
+  assert.strictEqual(state.primary.oopMax, 5000);
   assert.equal(state.secondary, undefined);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,6 @@ import {
 import { ResponsibilityBreakdown } from './components/ResponsibilityBreakdown';
 
 const emptyInsurance: Insurance = {
-  name: '',
   deductible: 0,
   oopMax: 0,
   coInsurance: 0,

--- a/src/components/InsuranceCard.tsx
+++ b/src/components/InsuranceCard.tsx
@@ -17,14 +17,14 @@ export default function InsuranceCard({
   const updateInsuranceField = (
     insurance: Insurance,
     field: keyof Insurance,
-    value: string | number
+    value: number
   ): Insurance => {
     return { ...insurance, [field]: value };
   };
 
   const handleChange = useCallback(
     (field: keyof Insurance) => (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = field === 'name' ? e.target.value : Number(e.target.value);
+      const value = Number(e.target.value);
       onChange(updateInsuranceField(insurance, field, value));
     },
     [insurance, onChange]
@@ -38,18 +38,6 @@ export default function InsuranceCard({
         {label}
       </h2>
       <div className="flex flex-col gap-4">
-        <fieldset className="fieldset">
-          <legend className="fieldset-legend">Name</legend>
-          <label className="input input-bordered flex items-center gap-2 w-full">
-            <i aria-hidden="true" className="fa-solid fa-id-card opacity-50" />
-            <input
-              type="text"
-              className="grow"
-              value={insurance.name}
-              onChange={handleChange('name')}
-            />
-          </label>
-        </fieldset>
         <fieldset className="fieldset">
           <legend className="fieldset-legend">Deductible</legend>
           <label className="input input-bordered flex items-center gap-2 w-full">

--- a/src/store/insuranceSlice.ts
+++ b/src/store/insuranceSlice.ts
@@ -7,7 +7,6 @@ export interface InsuranceUsage {
 }
 
 export interface Insurance {
-  name: string;
   deductible: number;
   oopMax: number;
   coInsurance: number;
@@ -21,7 +20,6 @@ interface InsuranceState {
 }
 
 const emptyInsurance: Insurance = {
-  name: '',
   deductible: 0,
   oopMax: 0,
   coInsurance: 0,


### PR DESCRIPTION
This pull request removes the `name` field from the `Insurance` interface and updates related components, tests, and logic accordingly. The changes simplify the `Insurance` model and ensure consistency across the codebase.

### Removal of `name` field from `Insurance` interface:
* [`src/store/insuranceSlice.ts`](diffhunk://#diff-a45f3ca6d05f4a2609a0c7aa11f25d55a0699675aeda784e0e3d74dcfbf3c46bL10): Removed the `name` field from the `Insurance` interface and updated the `emptyInsurance` object accordingly. [[1]](diffhunk://#diff-a45f3ca6d05f4a2609a0c7aa11f25d55a0699675aeda784e0e3d74dcfbf3c46bL10) [[2]](diffhunk://#diff-a45f3ca6d05f4a2609a0c7aa11f25d55a0699675aeda784e0e3d74dcfbf3c46bL24)

### Updates to components:
* [`src/components/InsuranceCard.tsx`](diffhunk://#diff-595a940befeb13c7d61202d64b9df6bbc6363dfe8e5971ae69c492ae1b80f93cL20-R27): Removed the input field for `name` from the UI and adjusted the `updateInsuranceField` and `handleChange` methods to no longer handle string values. [[1]](diffhunk://#diff-595a940befeb13c7d61202d64b9df6bbc6363dfe8e5971ae69c492ae1b80f93cL20-R27) [[2]](diffhunk://#diff-595a940befeb13c7d61202d64b9df6bbc6363dfe8e5971ae69c492ae1b80f93cL41-L52)

### Updates to tests:
* [`__tests__/insuranceSlice.test.ts`](diffhunk://#diff-4c6e2ad68c5eb34ddd4a5c720dfbc3074a79e56897f045fe7cda041d0d82e7ecL13): Updated test cases to remove assertions related to the `name` field and replaced them with assertions for other fields like `oopMax` and `copay`. [[1]](diffhunk://#diff-4c6e2ad68c5eb34ddd4a5c720dfbc3074a79e56897f045fe7cda041d0d82e7ecL13) [[2]](diffhunk://#diff-4c6e2ad68c5eb34ddd4a5c720dfbc3074a79e56897f045fe7cda041d0d82e7ecL23-R22) [[3]](diffhunk://#diff-4c6e2ad68c5eb34ddd4a5c720dfbc3074a79e56897f045fe7cda041d0d82e7ecL48-R56)

### Updates to `App.tsx`:
* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L15): Updated the `emptyInsurance` object to remove the `name` field.