### PR TITLE
Fix leading zero in insurance inputs

### DIFF
--- a/src/components/InsuranceCard.tsx
+++ b/src/components/InsuranceCard.tsx
@@ -1,5 +1,48 @@
-import { useCallback, type ReactNode } from 'react';
+import {
+  useCallback,
+  type ReactNode,
+  type InputHTMLAttributes,
+} from 'react';
 import type { Insurance } from '../store';
+
+interface FieldProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'className'> {
+  label: string;
+  tooltip: string;
+  prefix: string;
+  className?: string;
+}
+
+const Field = ({
+  label,
+  tooltip,
+  prefix,
+  className = '',
+  onFocus,
+  onChange,
+  value,
+  ...inputProps
+}: FieldProps) => (
+  <fieldset className={`fieldset ${className}`.trim()}>
+    <legend className="fieldset-legend flex items-center gap-2">
+      {label}
+      <div className="tooltip tooltip-right" data-tip={tooltip}>
+        <i aria-hidden="true" className="fa-solid fa-circle-info text-info cursor-pointer" />
+      </div>
+    </legend>
+    <label className="input input-bordered flex items-center gap-2 w-full">
+      <span className="opacity-50">{prefix}</span>
+      <input
+        type="number"
+        className="grow"
+        onFocus={onFocus}
+        value={value}
+        onChange={onChange}
+        {...inputProps}
+      />
+    </label>
+  </fieldset>
+);
 
 interface InsuranceCardProps {
   label: string;
@@ -30,6 +73,11 @@ export default function InsuranceCard({
     [insurance, onChange]
   );
 
+  const selectOnFocus = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    e.target.select();
+  }, []);
+
+
   return (
     <div className="card bg-base-200 shadow-xl p-4 relative dark:shadow-white/20">
       {cornerButton && <div className="absolute right-2 top-2">{cornerButton}</div>}
@@ -38,122 +86,56 @@ export default function InsuranceCard({
         {label}
       </h2>
       <div className="flex flex-col gap-4">
-        <fieldset className="fieldset">
-          <legend className="fieldset-legend flex items-center gap-2">
-            Deductible
-            <div
-              className="tooltip tooltip-right"
-              data-tip="The amount you pay before insurance starts covering costs."
-            >
-              <i aria-hidden="true" className="fa-solid fa-circle-info text-info cursor-pointer" />
-            </div>
-          </legend>
-          <label className="input input-bordered flex items-center gap-2 w-full">
-            <span className="opacity-50">$</span>
-            <input
-              type="number"
-              className="grow"
-              min="0"
-              value={insurance.deductible}
-              onChange={handleChange('deductible')}
-            />
-          </label>
-        </fieldset>
-
-        <fieldset className="fieldset">
-          <legend className="fieldset-legend flex items-center gap-2">
-            Copay
-            <div
-              className="tooltip tooltip-right"
-              data-tip="A fixed amount you pay for a covered service."
-            >
-              <i aria-hidden="true" className="fa-solid fa-circle-info text-info cursor-pointer" />
-            </div>
-          </legend>
-          <label className="input input-bordered flex items-center gap-2 w-full">
-            <span className="opacity-50">$</span>
-            <input
-              type="number"
-              className="grow"
-              min="0"
-              value={insurance.copay}
-              onChange={handleChange('copay')}
-            />
-          </label>
-        </fieldset>
-        <fieldset className="fieldset">
-          <legend className="fieldset-legend flex items-center gap-2">
-            Coinsurance
-            <div
-              className="tooltip tooltip-right"
-              data-tip="The percentage of costs you pay after meeting your deductible."
-            >
-              <i aria-hidden="true" className="fa-solid fa-circle-info text-info cursor-pointer" />
-            </div>
-          </legend>
-          <label className="input input-bordered flex items-center gap-2 w-full">
-            <span className="opacity-50">%</span>
-            <input
-              type="number"
-              className="grow"
-              step="0.01"
-              min="0"
-              max="1"
-              value={insurance.coInsurance}
-              onChange={handleChange('coInsurance')}
-            />
-          </label>
-        </fieldset>
-
+        <Field
+          label="Deductible"
+          tooltip="The amount you pay before insurance starts covering costs."
+          prefix="$"
+          value={insurance.deductible}
+          onChange={handleChange('deductible')}
+          onFocus={selectOnFocus}
+          min={0}
+        />
+        <Field
+          label="Copay"
+          tooltip="A fixed amount you pay for a covered service."
+          prefix="$"
+          value={insurance.copay}
+          onChange={handleChange('copay')}
+          onFocus={selectOnFocus}
+          min={0}
+        />
+        <Field
+          label="Coinsurance"
+          tooltip="The percentage of costs you pay after meeting your deductible."
+          prefix="%"
+          value={insurance.coInsurance}
+          onChange={handleChange('coInsurance')}
+          onFocus={selectOnFocus}
+          step="0.01"
+          min={0}
+          max={1}
+        />
         <div className="flex flex-row gap-4">
-          <fieldset className="fieldset flex-1">
-            <legend className="fieldset-legend flex items-center gap-2">
-              Out-of-pocket Max
-              <div
-                className="tooltip tooltip-right"
-                data-tip="The most you have to pay for covered services in a plan year."
-              >
-                <i
-                  aria-hidden="true"
-                  className="fa-solid fa-circle-info text-info cursor-pointer"
-                />
-              </div>
-            </legend>
-            <label className="input input-bordered flex items-center gap-2 w-full">
-              <span className="opacity-50">$</span>
-              <input
-                type="number"
-                className="grow"
-                min="0"
-                value={insurance.oopMax}
-                onChange={handleChange('oopMax')}
-              />
-            </label>
-          </fieldset>
-          <fieldset className="fieldset flex-1">
-            <legend className="fieldset-legend flex items-center gap-2">
-              OOP Used
-              <div
-                className="tooltip tooltip-right"
-                data-tip="How much of your out-of-pocket max you've already paid this year."
-              >
-                <i
-                  aria-hidden="true"
-                  className="fa-solid fa-circle-info text-info cursor-pointer"
-                />
-              </div>
-            </legend>
-            <label className="input input-bordered flex items-center gap-2 w-full">
-              <span className="opacity-50">$</span>
-              <input
-                type="number"
-                className="grow"
-                min="0"
-                value={insurance.oopUsed}
-                onChange={handleChange('oopUsed')}
-              />
-            </label>
-          </fieldset>
+          <Field
+            className="flex-1"
+            label="Out-of-pocket Max"
+            tooltip="The most you have to pay for covered services in a plan year."
+            prefix="$"
+            value={insurance.oopMax}
+            onChange={handleChange('oopMax')}
+            onFocus={selectOnFocus}
+            min={0}
+          />
+          <Field
+            className="flex-1"
+            label="OOP Used"
+            tooltip="How much of your out-of-pocket max you've already paid this year."
+            prefix="$"
+            value={insurance.oopUsed}
+            onChange={handleChange('oopUsed')}
+            onFocus={selectOnFocus}
+            min={0}
+          />
         </div>
         <input
           type="range"


### PR DESCRIPTION
## Summary
- select input text on focus via useCallback
- deduplicate InsuranceCard fieldsets with helper component
- move helper outside of `InsuranceCard`

## Testing
- `npm test` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850b8f209d48325b7ff05c96092241c


This pull request refactors the `InsuranceCard` component to improve code reuse and simplify its structure. The changes introduce a reusable `Field` component for form fields, replacing repetitive fieldset code. Additionally, a utility function (`selectOnFocus`) is added to enhance user interaction.

### Component Refactoring:

* **Introduced `Field` Component**: Created a reusable `Field` component to encapsulate common fieldset functionality, including labels, tooltips, prefixes, and input handling. This reduces code duplication and improves maintainability.
* **Replaced Fieldsets with `Field` Component**: Updated the `InsuranceCard` component to use the new `Field` component for all form fields (e.g., Deductible, Copay, Coinsurance, Out-of-pocket Max, OOP Used), simplifying the JSX structure and ensuring consistent styling.

### User Interaction Enhancement:

* **Added `selectOnFocus` Utility**: Introduced a `selectOnFocus` callback to automatically select the input value when a field gains focus, improving usability for numeric inputs. This is applied to all fields in the `InsuranceCard` component.