### PR TITLE
Add version number to footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import {
 } from './store/insuranceSlice';
 import { ResponsibilityBreakdown } from './components/ResponsibilityBreakdown';
 
+const version = __VERSION__;
+
 const emptyInsurance: Insurance = {
   deductible: 0,
   oopMax: 0,
@@ -93,7 +95,8 @@ function App() {
       </div>
       {secondary && <ResponsibilityBreakdown />}
       <footer className="text-center text-xs opacity-70 mt-4">
-        This is purely an estimate and calculations could be incorrect.
+        <p>This is purely an estimate and calculations could be incorrect.</p>
+        <p className="mt-1">v{version}</p>
       </footer>
     </div>
   );

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,4 +6,7 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
   base: '/medical-out-of-pocket/',
   plugins: [react(), tailwindcss()],
+  define: {
+    __VERSION__: JSON.stringify(process.env.npm_package_version),
+  },
 });


### PR DESCRIPTION
## Summary
- show version in UI by injecting it at build time via `__VERSION__`
- prefix version string in footer with `v`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854d67c203083258dc4d84ffc308b45