### PR TITLE
docs: expand README with usage and project details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,46 @@
-# React + TypeScript + Vite
+# Insurance Expense Calculator
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A web application for estimating annual out-of-pocket medical costs. The app is built with React, TypeScript, and Vite and uses Redux Toolkit for state management.
 
-Currently, two official plugins are available:
+## Features
+- Track medical expenses and insurance payments
+- Search saved records with fuzzy matching
+- Persist data locally so information is available after refreshing
+- Styled with Tailwind CSS and DaisyUI components
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Getting Started
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config({
-  extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
-    ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
-    ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
-    ...tseslint.configs.stylisticTypeChecked,
-  ],
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-});
+### Install dependencies
+```bash
+npm install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x';
-import reactDom from 'eslint-plugin-react-dom';
-
-export default tseslint.config({
-  plugins: {
-    // Add the react-x and react-dom plugins
-    'react-x': reactX,
-    'react-dom': reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
-  },
-});
+### Run the development server
+```bash
+npm run dev
 ```
+The app will be available at http://localhost:5173/.
+
+### Run tests
+```bash
+npm test
+```
+
+### Build for production
+```bash
+npm run build
+```
+The production-ready files will be output to the `dist/` directory.
+
+## Project Structure
+- `src/` – application source code
+- `__tests__/` – unit tests
+- `public/` – static assets
+
+## Technology Stack
+- React 19 + TypeScript
+- Vite for bundling and development server
+- Redux Toolkit and redux-persist
+- Tailwind CSS with DaisyUI
+- Jest and React Testing Library
+


### PR DESCRIPTION
## Summary
- rewrite README with project overview
- document setup, tests, and build commands
- list key technologies and project structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689915778d088325b0727850fd0d36b4