### PR TITLE
Add primary insurance reset control

### DIFF
--- a/__tests__/store/insuranceSlice.test.ts
+++ b/__tests__/store/insuranceSlice.test.ts
@@ -3,7 +3,9 @@ import reducer, {
   updatePrimaryOOPUsage,
   setSecondaryInsurance,
   updateSecondaryOOPUsage,
+  clearPrimaryInsurance,
   clearSecondaryInsurance,
+  emptyInsurance,
   swapInsurances,
 } from '../../src/store/insuranceSlice';
 
@@ -75,6 +77,22 @@ describe('insuranceSlice reducer', () => {
     it('does nothing if secondary is already undefined', () => {
       const state = reducer({ primary: sampleIns }, clearSecondaryInsurance());
       expect(state.secondary).toBeUndefined();
+    });
+  });
+
+  describe('clearPrimaryInsurance', () => {
+    it('resets primary to empty values', () => {
+      const state = reducer({ primary: sampleIns }, clearPrimaryInsurance());
+      expect(state.primary).toEqual(emptyInsurance);
+    });
+
+    it('does not affect secondary', () => {
+      const secondary = { ...sampleIns, deductible: 123 };
+      const state = reducer(
+        { primary: sampleIns, secondary },
+        clearPrimaryInsurance()
+      );
+      expect(state.secondary).toEqual(secondary);
     });
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,19 +7,13 @@ import { type AppDispatch, type RootState, type Insurance } from './store';
 import {
   setPrimaryInsurance,
   setSecondaryInsurance,
+  clearPrimaryInsurance,
   clearSecondaryInsurance,
+  emptyInsurance,
 } from './store/insuranceSlice';
 import { ResponsibilityBreakdown } from './components/ResponsibilityBreakdown';
 
 const version = __VERSION__;
-
-const emptyInsurance: Insurance = {
-  deductible: 0,
-  oopMax: 0,
-  coInsurance: 0,
-  copay: 0,
-  oopUsed: 0,
-};
 
 function App() {
   const dispatch = useDispatch<AppDispatch>();
@@ -44,6 +38,10 @@ function App() {
     }
   }, [dispatch, secondary]);
 
+  const clearPrimary = useCallback(() => {
+    dispatch(clearPrimaryInsurance());
+  }, [dispatch]);
+
   const removeSecondary = useCallback(() => {
     dispatch(clearSecondaryInsurance());
   }, [dispatch]);
@@ -64,15 +62,24 @@ function App() {
             insurance={primary}
             onChange={handlePrimaryChange}
             cornerButton={
-              !secondary && (
+              <div className="flex gap-1">
                 <button
-                  className="btn btn-circle btn-xs btn-primary"
-                  onClick={addSecondary}
-                  aria-label="Add Secondary Insurance"
+                  className="btn btn-circle btn-xs btn-warning"
+                  onClick={clearPrimary}
+                  aria-label="Clear Primary Insurance"
                 >
-                  <i className="fa-solid fa-plus" aria-hidden="true" />
+                  <i className="fa-solid fa-broom" aria-hidden="true" />
                 </button>
-              )
+                {!secondary && (
+                  <button
+                    className="btn btn-circle btn-xs btn-primary"
+                    onClick={addSecondary}
+                    aria-label="Add Secondary Insurance"
+                  >
+                    <i className="fa-solid fa-plus" aria-hidden="true" />
+                  </button>
+                )}
+              </div>
             }
           />
         </div>

--- a/src/store/insuranceSlice.ts
+++ b/src/store/insuranceSlice.ts
@@ -19,7 +19,7 @@ interface InsuranceState {
   secondary?: Insurance;
 }
 
-const emptyInsurance: Insurance = {
+export const emptyInsurance: Insurance = {
   deductible: 0,
   oopMax: 0,
   coInsurance: 0,
@@ -49,6 +49,9 @@ const insuranceSlice = createSlice({
         state.secondary.oopUsed = action.payload;
       }
     },
+    clearPrimaryInsurance: (state) => {
+      state.primary = emptyInsurance;
+    },
     clearSecondaryInsurance: (state) => {
       state.secondary = undefined;
     },
@@ -67,6 +70,7 @@ export const {
   updatePrimaryOOPUsage,
   setSecondaryInsurance,
   updateSecondaryOOPUsage,
+  clearPrimaryInsurance,
   clearSecondaryInsurance,
   swapInsurances,
 } = insuranceSlice.actions;


### PR DESCRIPTION
## Summary
- allow clearing the primary insurance in the store
- expose the empty insurance constant for reuse
- add button in UI to reset primary insurance values
- test the new reducer behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685618a485488325b69f3270768b28fd