### PR TITLE
feat(procedures): add quantity field

### DIFF
--- a/__tests__/store/proceduresSlice.test.ts
+++ b/__tests__/store/proceduresSlice.test.ts
@@ -18,69 +18,90 @@ describe('proceduresSlice', () => {
   describe('addProcedure', () => {
     it('should add a procedure', () => {
       const prevState = { list: [], selectedIds: {} as Record<string, boolean> };
-      const action = addProcedure({ id: 'ignored', name: 'Proc', cost: 100 });
+      const action = addProcedure({ name: 'Proc', cost: 100 });
       const nextState = proceduresReducer(prevState, action);
       expect(nextState.list.length).toBe(1);
       expect(nextState.list[0]).toEqual(
         expect.objectContaining({
           name: 'Proc',
           cost: 100,
+          quantity: 1,
         })
       );
     });
 
     it('should generate a unique id when adding a procedure', () => {
       const prevState = { list: [], selectedIds: {} as Record<string, boolean> };
-      const action = addProcedure({ id: 'ignored', name: 'Proc', cost: 100 });
-      const nextState = proceduresReducer(prevState, action);
-      expect(nextState.list[0].id).toBeDefined();
-      expect(typeof nextState.list[0].id).toBe('string');
-      expect(nextState.list[0].id).not.toBe('ignored');
+      const state1 = proceduresReducer(prevState, addProcedure({ name: 'A', cost: 100 }));
+      const state2 = proceduresReducer(state1, addProcedure({ name: 'B', cost: 200 }));
+      expect(state1.list[0].id).toBeDefined();
+      expect(state2.list[1].id).toBeDefined();
+      expect(state1.list[0].id).not.toBe(state2.list[1].id);
     });
 
     it('should select the newly added procedure by default', () => {
       const prevState = { list: [], selectedIds: {} as Record<string, boolean> };
-      const action = addProcedure({ id: 'ignored', name: 'Proc', cost: 100 });
+      const action = addProcedure({ name: 'Proc', cost: 100 });
       const nextState = proceduresReducer(prevState, action);
       const newId = nextState.list[0].id;
       expect(nextState.selectedIds[newId]).toBe(true);
+    });
+
+    it('defaults quantity to 1 when not provided', () => {
+      const prevState = { list: [], selectedIds: {} as Record<string, boolean> };
+      const action = addProcedure({ name: 'NoQty', cost: 50 });
+      const nextState = proceduresReducer(prevState, action);
+      expect(nextState.list[0].quantity).toBe(1);
     });
   });
 
   describe('updateProcedure', () => {
     it('should update a procedure', () => {
       const prevState = {
-        list: [{ id: '1', name: 'Old', cost: 50 }],
+        list: [{ id: '1', name: 'Old', cost: 50, quantity: 1 }],
         selectedIds: {} as Record<string, boolean>,
       };
       const action = {
         type: 'procedures/updateProcedure',
-        payload: { id: '1', name: 'New', cost: 200 },
+        payload: { id: '1', name: 'New', cost: 200, quantity: 1 },
       };
       const nextState = proceduresReducer(prevState, action);
       expect(nextState.list[0]).toEqual({
         id: '1',
         name: 'New',
-        cost: 200,
+        cost: 200, quantity: 1,
       });
     });
 
-    it('should not update a procedure if id does not exist', () => {
+    it('should update quantity of a procedure', () => {
       const prevState = {
-        list: [{ id: '1', name: 'A', cost: 10 }],
+        list: [{ id: '1', name: 'Test', cost: 50, quantity: 1 }],
         selectedIds: {},
       };
       const action = {
         type: 'procedures/updateProcedure',
-        payload: { id: '2', name: 'B', cost: 20 },
+        payload: { id: '1', quantity: 5 },
       };
       const nextState = proceduresReducer(prevState, action);
-      expect(nextState.list[0]).toEqual({ id: '1', name: 'A', cost: 10 });
+      expect(nextState.list[0]).toEqual({ id: '1', name: 'Test', cost: 50, quantity: 5 });
+    });
+
+    it('should not update a procedure if id does not exist', () => {
+      const prevState = {
+        list: [{ id: '1', name: 'A', cost: 10, quantity: 1 }],
+        selectedIds: {},
+      };
+      const action = {
+        type: 'procedures/updateProcedure',
+        payload: { id: '2', name: 'B', cost: 20, quantity: 1 },
+      };
+      const nextState = proceduresReducer(prevState, action);
+      expect(nextState.list[0]).toEqual({ id: '1', name: 'A', cost: 10, quantity: 1 });
     });
 
     it('should not update name or cost if action.payload.name and action.payload.cost are undefined', () => {
       const prevState = {
-        list: [{ id: '1', name: 'Original', cost: 123 }],
+        list: [{ id: '1', name: 'Original', cost: 123, quantity: 1 }],
         selectedIds: {},
       };
       const action = {
@@ -88,7 +109,7 @@ describe('proceduresSlice', () => {
         payload: { id: '1' }, // name and cost are undefined
       };
       const nextState = proceduresReducer(prevState, action);
-      expect(nextState.list[0]).toEqual({ id: '1', name: 'Original', cost: 123 });
+      expect(nextState.list[0]).toEqual({ id: '1', name: 'Original', cost: 123, quantity: 1 });
     });
   });
 
@@ -96,8 +117,8 @@ describe('proceduresSlice', () => {
     it('should remove a procedure', () => {
       const prevState = {
         list: [
-          { id: '1', name: 'A', cost: 10 },
-          { id: '2', name: 'B', cost: 20 },
+          { id: '1', name: 'A', cost: 10, quantity: 1 },
+          { id: '2', name: 'B', cost: 20, quantity: 1 },
         ],
         selectedIds: {} as Record<string, boolean>,
       };
@@ -109,7 +130,7 @@ describe('proceduresSlice', () => {
 
     it('should remove procedure from selectedIds when removed', () => {
       const prevState = {
-        list: [{ id: '1', name: 'A', cost: 10 }],
+        list: [{ id: '1', name: 'A', cost: 10, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const action = removeProcedure('1');
@@ -119,7 +140,7 @@ describe('proceduresSlice', () => {
 
     it('should not fail when removing a procedure that does not exist', () => {
       const prevState = {
-        list: [{ id: '1', name: 'A', cost: 10 }],
+        list: [{ id: '1', name: 'A', cost: 10, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const action = removeProcedure('2');
@@ -133,8 +154,8 @@ describe('proceduresSlice', () => {
     it('should remove all procedures and clear selectedIds', () => {
       const prevState = {
         list: [
-          { id: '1', name: 'A', cost: 10 },
-          { id: '2', name: 'B', cost: 20 },
+          { id: '1', name: 'A', cost: 10, quantity: 1 },
+          { id: '2', name: 'B', cost: 20, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -156,7 +177,7 @@ describe('proceduresSlice', () => {
   describe('toggleProcedure', () => {
     it('should toggle a procedure selection on', () => {
       const prevState = {
-        list: [{ id: '1', name: 'A', cost: 10 }],
+        list: [{ id: '1', name: 'A', cost: 10, quantity: 1 }],
         selectedIds: {} as Record<string, boolean>,
       };
       const action = toggleProcedure('1');
@@ -166,7 +187,7 @@ describe('proceduresSlice', () => {
 
     it('should toggle a procedure selection off', () => {
       const prevState = {
-        list: [{ id: '1', name: 'A', cost: 10 }],
+        list: [{ id: '1', name: 'A', cost: 10, quantity: 1 }],
         selectedIds: { '1': true } as Record<string, boolean>,
       };
       const action = toggleProcedure('1');
@@ -176,7 +197,7 @@ describe('proceduresSlice', () => {
 
     it('should do nothing when toggling a procedure not in list', () => {
       const prevState = {
-        list: [{ id: '1', name: 'A', cost: 10 }],
+        list: [{ id: '1', name: 'A', cost: 10, quantity: 1 }],
         selectedIds: {},
       };
       const action = toggleProcedure('2');
@@ -197,8 +218,8 @@ describe('proceduresSlice', () => {
     it('should toggle all procedures (select all)', () => {
       const prevState = {
         list: [
-          { id: '1', name: 'A', cost: 10 },
-          { id: '2', name: 'B', cost: 20 },
+          { id: '1', name: 'A', cost: 10, quantity: 1 },
+          { id: '2', name: 'B', cost: 20, quantity: 1 },
         ],
         selectedIds: {} as Record<string, boolean>,
       };
@@ -211,8 +232,8 @@ describe('proceduresSlice', () => {
     it('should toggle all procedures (deselect all)', () => {
       const prevState = {
         list: [
-          { id: '1', name: 'A', cost: 10 },
-          { id: '2', name: 'B', cost: 20 },
+          { id: '1', name: 'A', cost: 10, quantity: 1 },
+          { id: '2', name: 'B', cost: 20, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true } as Record<string, boolean>,
       };
@@ -224,8 +245,8 @@ describe('proceduresSlice', () => {
     it('should select all procedures if some are already selected', () => {
       const prevState = {
         list: [
-          { id: '1', name: 'A', cost: 10 },
-          { id: '2', name: 'B', cost: 20 },
+          { id: '1', name: 'A', cost: 10, quantity: 1 },
+          { id: '2', name: 'B', cost: 20, quantity: 1 },
         ],
         selectedIds: { '1': true },
       };
@@ -238,8 +259,8 @@ describe('proceduresSlice', () => {
     it('should clear selectedIds when all are selected and toggleAllProcedures is called', () => {
       const prevState = {
         list: [
-          { id: '1', name: 'A', cost: 10 },
-          { id: '2', name: 'B', cost: 20 },
+          { id: '1', name: 'A', cost: 10, quantity: 1 },
+          { id: '2', name: 'B', cost: 20, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };

--- a/__tests__/store/selectors.test.ts
+++ b/__tests__/store/selectors.test.ts
@@ -38,17 +38,17 @@ describe('selectors', () => {
         },
         procedures: {
           list: [
-            { id: '1', name: 'Procedure 1', cost: 100 },
-            { id: '2', name: 'Procedure 2', cost: 200 },
-            { id: '3', name: 'Procedure 3', cost: 300 },
+            { id: '1', name: 'Procedure 1', cost: 100, quantity: 1 },
+            { id: '2', name: 'Procedure 2', cost: 200, quantity: 1 },
+            { id: '3', name: 'Procedure 3', cost: 300, quantity: 1 },
           ],
           selectedIds: { '1': true, '3': true },
         },
       };
       expect(selectProcedures(state)).toEqual([
-        { id: '1', name: 'Procedure 1', cost: 100, selected: true },
-        { id: '2', name: 'Procedure 2', cost: 200, selected: false },
-        { id: '3', name: 'Procedure 3', cost: 300, selected: true },
+        { id: '1', name: 'Procedure 1', cost: 100, quantity: 1, selected: true },
+        { id: '2', name: 'Procedure 2', cost: 200, quantity: 1, selected: false },
+        { id: '3', name: 'Procedure 3', cost: 300, quantity: 1, selected: true },
       ]);
     });
 
@@ -56,8 +56,8 @@ describe('selectors', () => {
       const state: RootState = {
         procedures: {
           list: [
-            { id: '1', name: 'Procedure 1', cost: 100 },
-            { id: '2', name: 'Procedure 2', cost: 200 },
+            { id: '1', name: 'Procedure 1', cost: 100, quantity: 1 },
+            { id: '2', name: 'Procedure 2', cost: 200, quantity: 1 },
           ],
           selectedIds: {},
         },
@@ -74,8 +74,8 @@ describe('selectors', () => {
         },
       };
       expect(selectProcedures(state)).toEqual([
-        { id: '1', name: 'Procedure 1', cost: 100, selected: false },
-        { id: '2', name: 'Procedure 2', cost: 200, selected: false },
+        { id: '1', name: 'Procedure 1', cost: 100, quantity: 1, selected: false },
+        { id: '2', name: 'Procedure 2', cost: 200, quantity: 1, selected: false },
       ]);
     });
 
@@ -95,6 +95,29 @@ describe('selectors', () => {
       };
       expect(selectProcedures(state)).toEqual([]);
     });
+
+    it('defaults missing quantity to 1', () => {
+      const state: RootState = {
+        insurance: {
+          primary: {
+            deductible: 0,
+            deductibleUsed: 0,
+            copay: 0,
+            coInsurance: 0,
+            oopMax: 0,
+            oopUsed: 0,
+          },
+          secondary: undefined,
+        },
+        procedures: {
+          list: [{ id: '1', name: 'Procedure 1', cost: 100 }],
+          selectedIds: { '1': true },
+        },
+      };
+      expect(selectProcedures(state)).toEqual([
+        { id: '1', name: 'Procedure 1', cost: 100, quantity: 1, selected: true },
+      ]);
+    });
   });
 
   describe('sumSelectedProceduresCost', () => {
@@ -112,14 +135,37 @@ describe('selectors', () => {
         },
         procedures: {
           list: [
-            { id: '1', name: 'Procedure 1', cost: 100 },
-            { id: '2', name: 'Procedure 2', cost: 200 },
-            { id: '3', name: 'Procedure 3', cost: 300 },
+            { id: '1', name: 'Procedure 1', cost: 100, quantity: 1 },
+            { id: '2', name: 'Procedure 2', cost: 200, quantity: 1 },
+            { id: '3', name: 'Procedure 3', cost: 300, quantity: 1 },
           ],
           selectedIds: { '1': true, '3': true },
         },
       };
       expect(sumSelectedProceduresCost(state)).toBe(400);
+    });
+
+    it('multiplies cost by quantity', () => {
+      const state: RootState = {
+        insurance: {
+          primary: {
+            deductible: 0,
+            deductibleUsed: 0,
+            copay: 0,
+            coInsurance: 0,
+            oopMax: 0,
+            oopUsed: 0,
+          },
+        },
+        procedures: {
+          list: [
+            { id: '1', name: 'Proc 1', cost: 50, quantity: 2 },
+            { id: '2', name: 'Proc 2', cost: 25, quantity: 3 },
+          ],
+          selectedIds: { '1': true, '2': true },
+        },
+      };
+      expect(sumSelectedProceduresCost(state)).toBe(50 * 2 + 25 * 3);
     });
 
     it('returns 0 if no procedures are selected', () => {
@@ -136,8 +182,8 @@ describe('selectors', () => {
         },
         procedures: {
           list: [
-            { id: '1', name: 'Procedure 1', cost: 100 },
-            { id: '2', name: 'Procedure 2', cost: 200 },
+            { id: '1', name: 'Procedure 1', cost: 100, quantity: 1 },
+            { id: '2', name: 'Procedure 2', cost: 200, quantity: 1 },
           ],
           selectedIds: {},
         },
@@ -159,13 +205,33 @@ describe('selectors', () => {
         },
         procedures: {
           list: [
-            { id: '1', name: 'Procedure 1', cost: 0 },
-            { id: '3', name: 'Procedure 3', cost: 300 },
+            { id: '1', name: 'Procedure 1', cost: 0, quantity: 1 },
+            { id: '3', name: 'Procedure 3', cost: 300, quantity: 1 },
           ],
           selectedIds: { '1': true, '2': true, '3': true },
         },
       };
       expect(sumSelectedProceduresCost(state)).toBe(300);
+    });
+
+    it('treats missing quantity as 1', () => {
+      const state: RootState = {
+        insurance: {
+          primary: {
+            deductible: 0,
+            deductibleUsed: 0,
+            copay: 0,
+            coInsurance: 0,
+            oopMax: 0,
+            oopUsed: 0,
+          },
+        },
+        procedures: {
+          list: [{ id: '1', name: 'Proc', cost: 100 }],
+          selectedIds: { '1': true },
+        },
+      };
+      expect(sumSelectedProceduresCost(state)).toBe(100);
     });
 
     it('returns 0 if procedures list is empty', () => {
@@ -198,7 +264,7 @@ describe('selectors', () => {
           },
         },
         procedures: {
-          list: [{ id: '1', name: 'Procedure 1', cost: 100 }],
+          list: [{ id: '1', name: 'Procedure 1', cost: 100, quantity: 1 }],
           selectedIds: { '2': true },
         },
       };
@@ -218,8 +284,8 @@ describe('selectors', () => {
     it('returns 0 if total cost is 0', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 0 },
-          { id: '2', name: 'B', cost: 0 },
+          { id: '1', name: 'A', cost: 0, quantity: 1 },
+          { id: '2', name: 'B', cost: 0, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -238,8 +304,8 @@ describe('selectors', () => {
     it('applies deductible only if total cost <= deductible', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 100 },
-          { id: '2', name: 'B', cost: 50 },
+          { id: '1', name: 'A', cost: 100, quantity: 1 },
+          { id: '2', name: 'B', cost: 50, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -257,7 +323,7 @@ describe('selectors', () => {
 
     it('applies deductible, copay, and coinsurance', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 300 }],
+        list: [{ id: '1', name: 'A', cost: 300, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const insurance: Insurance = {
@@ -273,7 +339,7 @@ describe('selectors', () => {
 
     it('does not exceed out-of-pocket max', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 2000 }],
+        list: [{ id: '1', name: 'A', cost: 2000, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const insurance: Insurance = {
@@ -289,7 +355,7 @@ describe('selectors', () => {
 
     it('subtracts oopUsed from oopMax', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 2000 }],
+        list: [{ id: '1', name: 'A', cost: 2000, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const insurance: Insurance = {
@@ -305,7 +371,7 @@ describe('selectors', () => {
 
     it('handles zero copay and coinsurance', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 300 }],
+        list: [{ id: '1', name: 'A', cost: 300, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const insurance: Insurance = {
@@ -321,7 +387,7 @@ describe('selectors', () => {
 
     it('handles missing oopUsed as 0', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 1000 }],
+        list: [{ id: '1', name: 'A', cost: 1000, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const insurance: Insurance = {
@@ -350,8 +416,8 @@ describe('selectors', () => {
     it('returns patient responsibility after secondary insurance', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 500 },
-          { id: '2', name: 'B', cost: 500 },
+          { id: '1', name: 'A', cost: 500, quantity: 1 },
+          { id: '2', name: 'B', cost: 500, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -379,8 +445,8 @@ describe('selectors', () => {
     it('returns 0 if no secondary insurance and patient responsibility after primary is 0', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 0 },
-          { id: '2', name: 'B', cost: 0 },
+          { id: '1', name: 'A', cost: 0, quantity: 1 },
+          { id: '2', name: 'B', cost: 0, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -398,8 +464,8 @@ describe('selectors', () => {
     it('returns patient responsibility after primary if no secondary insurance', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 100 },
-          { id: '2', name: 'B', cost: 200 },
+          { id: '1', name: 'A', cost: 100, quantity: 1 },
+          { id: '2', name: 'B', cost: 200, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -419,7 +485,7 @@ describe('selectors', () => {
 
     it('does not exceed secondary out-of-pocket max', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 2000 }],
+        list: [{ id: '1', name: 'A', cost: 2000, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const primary: Insurance = {
@@ -445,7 +511,7 @@ describe('selectors', () => {
 
     it('subtracts oopUsed from secondary oopMax', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 1000 }],
+        list: [{ id: '1', name: 'A', cost: 1000, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const primary: Insurance = {
@@ -471,7 +537,7 @@ describe('selectors', () => {
 
     it('handles zero copay and coinsurance for secondary', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 300 }],
+        list: [{ id: '1', name: 'A', cost: 300, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const primary: Insurance = {
@@ -497,7 +563,7 @@ describe('selectors', () => {
 
     it('handles missing oopUsed as 0 for secondary', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 1000 }],
+        list: [{ id: '1', name: 'A', cost: 1000, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const primary: Insurance = {
@@ -534,8 +600,8 @@ describe('selectors', () => {
     it('returns the difference between patient responsibility after primary and after secondary', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 500 },
-          { id: '2', name: 'B', cost: 500 },
+          { id: '1', name: 'A', cost: 500, quantity: 1 },
+          { id: '2', name: 'B', cost: 500, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -563,8 +629,8 @@ describe('selectors', () => {
     it('returns 0 if patient responsibility after secondary equals after primary', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 100 },
-          { id: '2', name: 'B', cost: 200 },
+          { id: '1', name: 'A', cost: 100, quantity: 1 },
+          { id: '2', name: 'B', cost: 200, quantity: 1 },
         ],
         selectedIds: {},
       };
@@ -589,7 +655,7 @@ describe('selectors', () => {
 
     it('does not return negative values', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 100 }],
+        list: [{ id: '1', name: 'A', cost: 100, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const primary: Insurance = {
@@ -613,7 +679,7 @@ describe('selectors', () => {
 
     it('handles missing oopUsed as 0 for secondary', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 1000 }],
+        list: [{ id: '1', name: 'A', cost: 1000, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const primary: Insurance = {
@@ -639,8 +705,8 @@ describe('selectors', () => {
     it('returns 0 if no procedures are selected', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 100 },
-          { id: '2', name: 'B', cost: 200 },
+          { id: '1', name: 'A', cost: 100, quantity: 1 },
+          { id: '2', name: 'B', cost: 200, quantity: 1 },
         ],
         selectedIds: {},
       };
@@ -675,8 +741,8 @@ describe('selectors', () => {
     it('returns 0 if no procedures are selected', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 100 },
-          { id: '2', name: 'B', cost: 200 },
+          { id: '1', name: 'A', cost: 100, quantity: 1 },
+          { id: '2', name: 'B', cost: 200, quantity: 1 },
         ],
         selectedIds: {},
       };
@@ -694,8 +760,8 @@ describe('selectors', () => {
     it('returns 0 if patient responsibility equals total cost', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 100 },
-          { id: '2', name: 'B', cost: 200 },
+          { id: '1', name: 'A', cost: 100, quantity: 1 },
+          { id: '2', name: 'B', cost: 200, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -717,8 +783,8 @@ describe('selectors', () => {
     it('returns total cost minus patient responsibility', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 500 },
-          { id: '2', name: 'B', cost: 500 },
+          { id: '1', name: 'A', cost: 500, quantity: 1 },
+          { id: '2', name: 'B', cost: 500, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -741,7 +807,7 @@ describe('selectors', () => {
 
     it('never returns negative value', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 100 }],
+        list: [{ id: '1', name: 'A', cost: 100, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const primary: Insurance = {
@@ -757,7 +823,7 @@ describe('selectors', () => {
 
     it('handles missing oopUsed as 0', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 1000 }],
+        list: [{ id: '1', name: 'A', cost: 1000, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const primary: Insurance = {
@@ -787,8 +853,8 @@ describe('selectors', () => {
     it('returns correct total and percentage when secondary insurance reduces patient responsibility', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 500 },
-          { id: '2', name: 'B', cost: 500 },
+          { id: '1', name: 'A', cost: 500, quantity: 1 },
+          { id: '2', name: 'B', cost: 500, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -816,8 +882,8 @@ describe('selectors', () => {
     it('returns 0 total and 0 percentage if no procedures are selected', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 100 },
-          { id: '2', name: 'B', cost: 200 },
+          { id: '1', name: 'A', cost: 100, quantity: 1 },
+          { id: '2', name: 'B', cost: 200, quantity: 1 },
         ],
         selectedIds: {},
       };
@@ -845,8 +911,8 @@ describe('selectors', () => {
     it('returns correct total and percentage when there is no secondary insurance', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 100 },
-          { id: '2', name: 'B', cost: 200 },
+          { id: '1', name: 'A', cost: 100, quantity: 1 },
+          { id: '2', name: 'B', cost: 200, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -865,7 +931,7 @@ describe('selectors', () => {
     });
     it('handles missing oopUsed as 0 for secondary insurance', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 1000 }],
+        list: [{ id: '1', name: 'A', cost: 1000, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const primary: Insurance = {
@@ -892,8 +958,8 @@ describe('selectors', () => {
     it('returns correct total and percentage when both insurances pay', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 500 },
-          { id: '2', name: 'B', cost: 500 },
+          { id: '1', name: 'A', cost: 500, quantity: 1 },
+          { id: '2', name: 'B', cost: 500, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -922,8 +988,8 @@ describe('selectors', () => {
     it('returns 0 total and 0 percentage if no procedures are selected', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 100 },
-          { id: '2', name: 'B', cost: 200 },
+          { id: '1', name: 'A', cost: 100, quantity: 1 },
+          { id: '2', name: 'B', cost: 200, quantity: 1 },
         ],
         selectedIds: {},
       };
@@ -952,8 +1018,8 @@ describe('selectors', () => {
     it('returns correct total and percentage when there is no secondary insurance', () => {
       const procedures = {
         list: [
-          { id: '1', name: 'A', cost: 100 },
-          { id: '2', name: 'B', cost: 200 },
+          { id: '1', name: 'A', cost: 100, quantity: 1 },
+          { id: '2', name: 'B', cost: 200, quantity: 1 },
         ],
         selectedIds: { '1': true, '2': true },
       };
@@ -980,7 +1046,7 @@ describe('selectors', () => {
 
     it('handles missing oopUsed as 0 for secondary insurance', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 1000 }],
+        list: [{ id: '1', name: 'A', cost: 1000, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const primary: Insurance = {
@@ -1002,7 +1068,7 @@ describe('selectors', () => {
 
     it('never returns negative total or percentage', () => {
       const procedures = {
-        list: [{ id: '1', name: 'A', cost: 100 }],
+        list: [{ id: '1', name: 'A', cost: 100, quantity: 1 }],
         selectedIds: { '1': true },
       };
       const primary: Insurance = {

--- a/src/components/AddProcedure.tsx
+++ b/src/components/AddProcedure.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, type FC } from 'react';
 import { useDispatch } from 'react-redux';
-import type { AppDispatch, Procedure } from '../store';
+import type { AppDispatch } from '../store';
 import { addProcedure } from '../store/proceduresSlice';
 import useProcedureValidation from '../hooks/useProcedureValidation';
 import CPTs from './_cpt.json';
@@ -82,12 +82,12 @@ export const AddProcedure = () => {
 
   const handleAdd = useCallback(() => {
     if (isInvalid) return;
-    dispatch(addProcedure({ id: '', name, cost: parsedCost } as Procedure));
+    dispatch(addProcedure({ name, cost: parsedCost }));
     resetAddForm();
   }, [isInvalid, parsedCost, name, dispatch, resetAddForm]);
   return (
     <div className="join mb-2 items-start w-full">
-      <div className="dropdown join-item flex-2/3">
+      <div className="dropdown join-item flex-1">
         <label tabIndex={0} className="input input-bordered flex items-center gap-2 w-full">
           <span className="opacity-50">
             <i className="fa-solid fa-search mr-1" aria-hidden="true" />
@@ -104,7 +104,7 @@ export const AddProcedure = () => {
         </label>
         {name && <SearchList name={name} onNameChange={setName} />}
       </div>
-      <label className="input input-bordered validator join-item flex-1/3">
+      <label className="input input-bordered validator join-item w-24">
         <span>$</span>
         <input
           type="number"

--- a/src/components/ProcedureItem.tsx
+++ b/src/components/ProcedureItem.tsx
@@ -13,6 +13,7 @@ export default function ProcedureItem({ procedure }: ProcedureItemProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [name, setName] = useState(procedure.name);
   const [cost, setCost] = useState(procedure.cost.toString());
+  const [quantity, setQuantity] = useState((procedure.quantity ?? 1).toString());
   const { parsedCost, isInvalid, errorMessage } = useProcedureValidation(name, cost);
 
   const startEdit = useCallback(() => {
@@ -23,13 +24,15 @@ export default function ProcedureItem({ procedure }: ProcedureItemProps) {
     setIsEditing(false);
     setName(procedure.name);
     setCost(procedure.cost.toString());
-  }, [procedure.cost, procedure.name]);
+    setQuantity((procedure.quantity ?? 1).toString());
+  }, [procedure.cost, procedure.name, procedure.quantity]);
 
   const saveEdit = useCallback(() => {
     if (isInvalid) return;
-    dispatch(updateProcedure({ id: procedure.id, name, cost: parsedCost }));
+    const parsedQuantity = parseInt(quantity, 10) || 1;
+    dispatch(updateProcedure({ id: procedure.id, name, cost: parsedCost, quantity: parsedQuantity }));
     setIsEditing(false);
-  }, [dispatch, isInvalid, parsedCost, name, procedure.id]);
+  }, [dispatch, isInvalid, parsedCost, name, quantity, procedure.id]);
 
   const remove = useCallback(() => {
     dispatch(removeProcedure(procedure.id));
@@ -41,6 +44,10 @@ export default function ProcedureItem({ procedure }: ProcedureItemProps) {
 
   const handleCostChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setCost(e.target.value);
+  }, []);
+
+  const handleQuantityChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuantity(e.target.value);
   }, []);
 
   const handleToggle = useCallback(() => {
@@ -58,6 +65,16 @@ export default function ProcedureItem({ procedure }: ProcedureItemProps) {
               value={name}
               onChange={handleNameChange}
             />
+            <label className="input input-bordered validator join-item w-20">
+              <input
+                type="number"
+                className="grow"
+                min="1"
+                value={quantity}
+                onChange={handleQuantityChange}
+                required
+              />
+            </label>
             <label className="input input-bordered validator join-item w-24">
               <span>$</span>
               <input
@@ -93,7 +110,8 @@ export default function ProcedureItem({ procedure }: ProcedureItemProps) {
             onChange={handleToggle}
           />
           <span className="flex-1/2">{procedure.name}</span>
-          <span className="flex-1/6">${procedure.cost.toFixed(2)}</span>
+          <span className="w-10 text-center">{procedure.quantity ?? 1}</span>
+          <span className="flex-1/6">${(procedure.cost * (procedure.quantity ?? 1)).toFixed(2)}</span>
           <button className="btn btn-xs" onClick={startEdit}>
             <i className="fa-solid fa-pen" aria-hidden="true" />
           </button>

--- a/src/store/proceduresSlice.ts
+++ b/src/store/proceduresSlice.ts
@@ -5,6 +5,7 @@ export interface Procedure {
   id: string;
   name: string;
   cost: number;
+  quantity?: number;
 }
 
 export type ProcedureCreate = Omit<Procedure, 'id'>;
@@ -24,20 +25,21 @@ const proceduresSlice = createSlice({
   name: 'procedures',
   initialState,
   reducers: {
-    addProcedure: (state, action: PayloadAction<Procedure>) => {
+    addProcedure: (state, action: PayloadAction<ProcedureCreate>) => {
       const id = crypto.randomUUID();
-      state.list.push({ ...action.payload, id });
+      state.list.push({ ...action.payload, id, quantity: action.payload.quantity ?? 1 });
       state.selectedIds[id] = true; // Initialize as not selected
     },
     updateProcedure: (
       state,
-      action: PayloadAction<{ id: string; name?: string; cost?: number }>
+      action: PayloadAction<{ id: string; name?: string; cost?: number; quantity?: number }>
     ) => {
-      const { id, name, cost } = action.payload;
+      const { id, name, cost, quantity } = action.payload;
       const procedure = state.list.find((p) => p.id === id);
       if (procedure) {
         if (name !== undefined) procedure.name = name;
         if (cost !== undefined) procedure.cost = cost;
+        if (quantity !== undefined) procedure.quantity = quantity;
       }
     },
     removeProcedure: (state, action: PayloadAction<string>) => {

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -11,7 +11,8 @@ const mathjs = create(all, {
 
 export const selectProcedures = createSelector(
   (state: RootState) => state.procedures,
-  ({ list, selectedIds }) => list.map((p) => ({ ...p, selected: !!selectedIds[p.id] }))
+  ({ list, selectedIds }) =>
+    list.map((p) => ({ ...p, quantity: p.quantity ?? 1, selected: !!selectedIds[p.id] }))
 );
 
 export const sumSelectedProceduresCost = createSelector(
@@ -20,7 +21,7 @@ export const sumSelectedProceduresCost = createSelector(
     return Object.keys(selectedIds)
       .map((id) => list.find((p) => p.id === id))
       .filter((p) => !!p?.cost)
-      .reduce((sum, p) => mathjs.add(sum, p!.cost), 0);
+      .reduce((sum, p) => mathjs.add(sum, mathjs.multiply(p!.cost, p!.quantity ?? 1)), 0);
   }
 );
 


### PR DESCRIPTION
## Summary
- allow specifying quantity when editing procedures; new procedures default to a quantity of one
- handle undefined procedure quantity by coalescing to 1 in selectors
- drop quantity input from the add procedure form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689926fc1340832590682f14bbb0d2d4