### PR TITLE
feat: add primary insurance reset

### DIFF
--- a/__tests__/store/insuranceSlice.test.ts
+++ b/__tests__/store/insuranceSlice.test.ts
@@ -1,6 +1,7 @@
 import reducer, {
   setPrimaryInsurance,
   setSecondaryInsurance,
+  clearPrimaryInsurance,
   clearSecondaryInsurance,
   swapInsurances,
   Insurance,
@@ -31,6 +32,24 @@ describe('insuranceSlice reducer', () => {
   describe('setSecondaryInsurance', () => {
     it('sets secondary', () => {
       const state = reducer({ primary: sampleIns }, setSecondaryInsurance(sampleIns));
+      expect(state.secondary).toBeDefined();
+    });
+  });
+
+  describe('clearPrimaryInsurance', () => {
+    it('resets primary to empty values', () => {
+      const state = reducer(
+        { primary: sampleIns, secondary: sampleIns },
+        clearPrimaryInsurance()
+      );
+      expect(state.primary).toEqual({
+        deductible: 0,
+        deductibleUsed: 0,
+        oopMax: 0,
+        coInsurance: 0,
+        copay: 0,
+        oopUsed: 0,
+      });
       expect(state.secondary).toBeDefined();
     });
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { type AppDispatch, type RootState, type Insurance } from './store';
 import {
   setPrimaryInsurance,
   setSecondaryInsurance,
+  clearPrimaryInsurance,
   clearSecondaryInsurance,
 } from './store/insuranceSlice';
 import { ResponsibilityBreakdown } from './components/ResponsibilityBreakdown';
@@ -49,6 +50,10 @@ function App() {
     dispatch(clearSecondaryInsurance());
   }, [dispatch]);
 
+  const clearPrimary = useCallback(() => {
+    dispatch(clearPrimaryInsurance());
+  }, [dispatch]);
+
   return (
     <div className="flex flex-col w-full gap-4 p-4">
       <header className="mb-4 text-center">
@@ -65,15 +70,24 @@ function App() {
             insurance={primary}
             onChange={handlePrimaryChange}
             cornerButton={
-              !secondary && (
+              <div className="join">
                 <button
-                  className="btn btn-circle btn-xs btn-primary"
-                  onClick={addSecondary}
-                  aria-label="Add Secondary Insurance"
+                  className="btn btn-circle btn-xs btn-error join-item"
+                  onClick={clearPrimary}
+                  aria-label="Clear Primary Insurance"
                 >
-                  <i className="fa-solid fa-plus" aria-hidden="true" />
+                  <i className="fa-solid fa-trash" aria-hidden="true" />
                 </button>
-              )
+                {!secondary && (
+                  <button
+                    className="btn btn-circle btn-xs btn-primary join-item"
+                    onClick={addSecondary}
+                    aria-label="Add Secondary Insurance"
+                  >
+                    <i className="fa-solid fa-plus" aria-hidden="true" />
+                  </button>
+                )}
+              </div>
             }
           />
         </div>

--- a/src/store/insuranceSlice.ts
+++ b/src/store/insuranceSlice.ts
@@ -38,6 +38,9 @@ const insuranceSlice = createSlice({
     setSecondaryInsurance: (state, action: PayloadAction<Insurance>) => {
       state.secondary = action.payload;
     },
+    clearPrimaryInsurance: (state) => {
+      state.primary = { ...emptyInsurance };
+    },
     clearSecondaryInsurance: (state) => {
       state.secondary = undefined;
     },
@@ -54,6 +57,7 @@ const insuranceSlice = createSlice({
 export const {
   setPrimaryInsurance,
   setSecondaryInsurance,
+  clearPrimaryInsurance,
   clearSecondaryInsurance,
   swapInsurances,
 } = insuranceSlice.actions;


### PR DESCRIPTION
## Summary
- allow resetting primary insurance to default values
- add UI control to clear primary insurance details
- cover reset logic with reducer tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68992eb73cb48325b0b08c55b8f6b2b2